### PR TITLE
Add close all folders button in file section

### DIFF
--- a/src/views/Workspace.jsx
+++ b/src/views/Workspace.jsx
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { confirm } from "@tauri-apps/plugin-dialog";
 import { DndContext, useDraggable, useDroppable, useSensor, useSensors, PointerSensor } from "@dnd-kit/core";
 import { DraggableTab } from "./DraggableTab";
-import { Menu, FilePlus2, FolderPlus, Search, Share2 } from "lucide-react";
+import { Menu, FilePlus2, FolderPlus, Search, Share2, FolderMinus } from "lucide-react";
 // import GraphView from "./GraphView.jsx"; // Temporarily disabled
 import Editor from "../editor";
 import FileContextMenu from "../components/FileContextMenu.jsx";
@@ -593,6 +593,10 @@ export default function Workspace({ initialPath = "" }) {
     });
   };
 
+  const closeAllFolders = () => {
+    setExpandedFolders(new Set());
+  };
+
   const handleFileOpen = (file) => {
     if (file.is_directory) return;
 
@@ -908,6 +912,14 @@ export default function Workspace({ initialPath = "" }) {
                       >
                         <FolderPlus className="w-4 h-4" />
                         New folder
+                      </button>
+                      <button
+                        onClick={closeAllFolders}
+                        className="inline-flex items-center gap-2 rounded-md border border-app-border bg-app-bg px-4 py-2 text-sm hover:bg-app-panel transition-colors"
+                        title="Close all folders"
+                      >
+                        <FolderMinus className="w-4 h-4" />
+                        Close all
                       </button>
                       <button
                         onClick={handleRefreshFiles}


### PR DESCRIPTION
## Summary

Adds a convenient "Close all" button in the file section to quickly collapse all expanded folders in the file tree.

### ✨ Feature Request
User requested a button beside the "New file" and "New folder" buttons that closes/collapses all open folders in the file tree.

### 🎯 Implementation
- **Icon**: Added `FolderMinus` icon from lucide-react for clear visual indication
- **Function**: `closeAllFolders()` clears the `expandedFolders` Set to collapse all folders
- **Position**: Placed between "New folder" and "Refresh files" buttons for logical grouping
- **UX**: Added tooltip "Close all folders" for clarity

### 🎨 UI Changes
- Button follows the same styling as other file section buttons
- Consistent spacing and hover effects
- FolderMinus icon clearly indicates the action

### 🧪 Testing
- ✅ All existing tests pass
- ✅ No regressions introduced
- ✅ Feature integrates cleanly with existing file tree functionality

### 📝 Files Changed
- `src/views/Workspace.jsx`: Added button, function, and icon import

### 🔍 How to Use
1. Open some folders in the file tree
2. Click the "Close all" button (FolderMinus icon)
3. All folders will be collapsed instantly

🤖 Generated with [Claude Code](https://claude.ai/code)