### PR TITLE
fix: allow workspace and preferences windows to read config files

### DIFF
--- a/src-tauri/capabilities/fs-home.json
+++ b/src-tauri/capabilities/fs-home.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0/capabilities.json",
   "identifier": "fs-home-scope",
-  "description": "Filesystem permissions and HOME scope for the main window.",
-  "windows": ["main"],
+  "description": "Filesystem permissions and HOME scope for all application windows.",
+  "windows": ["main", "ws-lokus-workspace", "prefs", "ws-*"],
   "permissions": [
     "fs:default",
     {


### PR DESCRIPTION
## Summary
- Fixed theme persistence issue where workspace and preferences windows were denied FS permissions to read config files
- Added workspace windows ("ws-lokus-workspace", "ws-*") and preferences window ("prefs") to fs-home.json capabilities
- Resolves console errors: "fs.read_text_file not allowed on window"

## Problem
The user reported that:
1. Welcome window displays the correct custom theme
2. Workspace window reverts to default theme due to permission errors
3. Preferences window has the same FS permission issue
4. Console shows: `fs.read_text_file not allowed on window "ws-lokus-workspace"`

## Solution
Modified `src-tauri/capabilities/fs-home.json` to include all window types:
- `"main"` (existing)
- `"ws-lokus-workspace"` (workspace windows)
- `"prefs"` (preferences window)  
- `"ws-*"` (any workspace window pattern)

## Test plan
- [x] Build app with new permissions
- [x] Verify app starts without permission errors
- [x] Test theme persistence across different window types
- [x] Confirm workspace windows can read config files
- [x] Confirm preferences window can read config files

🤖 Generated with [Claude Code](https://claude.ai/code)