### PR TITLE
fix: make WikiLink autocomplete dialog responsive (#259)

### DIFF
--- a/src/editor/lib/WikiLinkSuggest.js
+++ b/src/editor/lib/WikiLinkSuggest.js
@@ -461,9 +461,40 @@ const WikiLinkSuggest = Extension.create({
           let container
           const place = (rect) => {
             if (!container || !rect) return
-            container.style.left = `${Math.max(8, rect.left)}px`
-            container.style.top = `${Math.min(window.innerHeight - 16, rect.bottom + 6)}px`
-            container.style.width = '384px'
+            const dialogWidth = 384
+            const padding = 16
+            const viewportWidth = window.innerWidth
+            const viewportHeight = window.innerHeight
+
+            // Calculate initial position
+            let left = rect.left
+            let top = rect.bottom + 6
+
+            // Check right edge overflow
+            if (left + dialogWidth + padding > viewportWidth) {
+              left = viewportWidth - dialogWidth - padding
+            }
+
+            // Check left edge
+            if (left < padding) {
+              left = padding
+            }
+
+            // Get container height for bottom edge check
+            const containerHeight = container.offsetHeight || 300 // fallback estimate
+
+            // Check bottom edge overflow - position above cursor if needed
+            if (top + containerHeight + padding > viewportHeight) {
+              top = rect.top - containerHeight - 6
+              // If still goes beyond top edge, align to top with padding
+              if (top < padding) {
+                top = padding
+              }
+            }
+
+            container.style.left = `${left}px`
+            container.style.top = `${top}px`
+            container.style.width = `${dialogWidth}px`
           }
           return {
             onStart: (props) => {
@@ -473,7 +504,7 @@ const WikiLinkSuggest = Extension.create({
                 const range = props.range
                 const textBefore = props.editor.state.doc.textBetween(Math.max(0, range.from - 2), range.from)
                 const isWikiLink = textBefore.endsWith('[')
-                
+
                 if (isWikiLink) {
                   const pos = Math.max(0, Math.min(props.editor.state.doc.content.size, (props.range?.to ?? props.editor.state.selection.to)))
                   const next = props.editor.state.doc.textBetween(pos, Math.min(props.editor.state.doc.content.size, pos + 2))
@@ -608,9 +639,40 @@ const WikiLinkSuggest = Extension.create({
           let container
           const place = (rect) => {
             if (!container || !rect) return
-            container.style.left = `${Math.max(8, rect.left)}px`
-            container.style.top = `${Math.min(window.innerHeight - 16, rect.bottom + 6)}px`
-            container.style.width = '384px'
+            const dialogWidth = 384
+            const padding = 16
+            const viewportWidth = window.innerWidth
+            const viewportHeight = window.innerHeight
+
+            // Calculate initial position
+            let left = rect.left
+            let top = rect.bottom + 6
+
+            // Check right edge overflow
+            if (left + dialogWidth + padding > viewportWidth) {
+              left = viewportWidth - dialogWidth - padding
+            }
+
+            // Check left edge
+            if (left < padding) {
+              left = padding
+            }
+
+            // Get container height for bottom edge check
+            const containerHeight = container.offsetHeight || 300 // fallback estimate
+
+            // Check bottom edge overflow - position above cursor if needed
+            if (top + containerHeight + padding > viewportHeight) {
+              top = rect.top - containerHeight - 6
+              // If still goes beyond top edge, align to top with padding
+              if (top < padding) {
+                top = padding
+              }
+            }
+
+            container.style.left = `${left}px`
+            container.style.top = `${top}px`
+            container.style.width = `${dialogWidth}px`
           }
           return {
             onStart: (props) => {


### PR DESCRIPTION
## 📝 Description

**What type of PR is this?**
- [x] 🐛 Bug fix

**What does this PR do?**
Fixes the WikiLink autocomplete dialog positioning to prevent it from overflowing outside the application window when opened near viewport edges.

The dialog now:
- Shifts left when approaching the right edge
- Maintains minimum padding from the left edge
- Positions above the cursor when near the bottom edge
- Falls back to top padding if there's no space above

**Related issue(s):**
Fixes #259

## 🧪 Testing

**How was this tested?**
- [x] Manual testing performed

**Test scenarios covered:**
- Typing `[[` near the right edge of a narrow window
- Typing `[[` near the bottom edge of the window
- Typing `[[` in the corner (right + bottom)
- Normal positioning when space is available

## 📋 Checklist

**Before submitting this PR, please make sure:**

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

**For bug fixes:**
- [x] I have verified the fix works in different scenarios
- [x] I have considered edge cases

## 🔄 Breaking Changes

- [x] This PR is backwards compatible

## 🏷️ Release Notes

**User-facing changes:**
WikiLink autocomplete dialog now stays within the window boundaries when typing `[[` near screen edges.
Photos how fix looks:

<img width="595" height="398" alt="image" src="https://github.com/user-attachments/assets/b4adb7fa-edd6-4735-8db0-01a5d0646dda" />
<img width="595" height="398" alt="image" src="https://github.com/user-attachments/assets/620332d4-a8ed-41fb-bdf4-185e3520391e" />
<img width="595" height="398" alt="image" src="https://github.com/user-attachments/assets/90ae3227-a9f3-4bd3-806e-5449043265bb" />
<img width="850" height="747" alt="image" src="https://github.com/user-attachments/assets/ef42acde-1da6-4099-b0af-84276f6c64c5" />

