### PR TITLE
WIP: Embedded Canvas - Draw directly in markdown (#269)

### DIFF
--- a/public/canvas-editor.html
+++ b/public/canvas-editor.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Canvas Editor</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html, body, #root {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+
+    /* Done button overlay */
+    .done-button {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 10000;
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+      transition: background 0.2s;
+    }
+
+    .done-button:hover {
+      background: #2563eb;
+    }
+
+    .done-button svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    /* Loading state */
+    .loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #666;
+      font-size: 16px;
+    }
+
+    /* Hide TLDraw's default UI elements we don't need */
+    .tl-container [data-testid="main-menu"] {
+      display: none !important;
+    }
+  </style>
+
+  <!-- Import map to ensure consistent React versions -->
+  <script type="importmap">
+  {
+    "imports": {
+      "react": "https://esm.sh/react@18.2.0",
+      "react-dom": "https://esm.sh/react-dom@18.2.0",
+      "react-dom/client": "https://esm.sh/react-dom@18.2.0/client",
+      "react/jsx-runtime": "https://esm.sh/react@18.2.0/jsx-runtime",
+      "tldraw": "https://esm.sh/tldraw@2.4.7?external=react,react-dom"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="root">
+    <div class="loading">Loading canvas editor...</div>
+  </div>
+
+  <script type="module">
+    // Import with proper module resolution
+    import React from 'react';
+    import * as ReactDOM from 'react-dom/client';
+    import { Tldraw, createTLStore, defaultShapeUtils, defaultBindingUtils, loadSnapshot, getSnapshot } from 'tldraw';
+
+    // Import TLDraw CSS
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://esm.sh/tldraw@2.4.7/tldraw.css';
+    document.head.appendChild(link);
+
+    // State
+    let store = null;
+    let editor = null;
+    let hasUnsavedChanges = false;
+
+    // Create TLDraw store
+    store = createTLStore({
+      shapeUtils: defaultShapeUtils,
+      bindingUtils: defaultBindingUtils
+    });
+
+    // Listen for messages from parent
+    window.addEventListener('message', (event) => {
+      const { type, data } = event.data || {};
+
+      switch (type) {
+        case 'load':
+          // Load fragment data into store
+          if (data && store) {
+            try {
+              loadSnapshot(store, data);
+              hasUnsavedChanges = false;
+            } catch (err) {
+              console.error('[Canvas Editor] Failed to load snapshot:', err);
+            }
+          }
+          break;
+
+        case 'theme':
+          // Theme updates handled by TLDraw's dark mode detection
+          break;
+      }
+    });
+
+    // Send message to parent
+    function sendToParent(type, data) {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type, data }, '*');
+      }
+    }
+
+    // Auto-save with debounce
+    let saveTimeout = null;
+    function scheduleAutoSave() {
+      if (saveTimeout) clearTimeout(saveTimeout);
+      saveTimeout = setTimeout(() => {
+        if (editor && hasUnsavedChanges) {
+          const snapshot = getSnapshot(editor.store);
+          sendToParent('save', snapshot);
+          hasUnsavedChanges = false;
+        }
+      }, 300);
+    }
+
+    // Handle done button click
+    function handleDone() {
+      if (editor) {
+        const snapshot = getSnapshot(editor.store);
+        sendToParent('save', snapshot);
+      }
+      sendToParent('done');
+    }
+
+    // Make handleDone available globally for the button
+    window.handleCanvasDone = handleDone;
+
+    // React App using createElement (no JSX needed)
+    function CanvasEditorApp() {
+      const handleMount = React.useCallback((editorInstance) => {
+        editor = editorInstance;
+
+        // Listen for changes
+        editor.store.listen(() => {
+          hasUnsavedChanges = true;
+          scheduleAutoSave();
+        });
+
+        // Tell parent we're ready
+        sendToParent('ready');
+      }, []);
+
+      return React.createElement('div', {
+        style: { width: '100%', height: '100%', position: 'relative' }
+      }, [
+        // Done button
+        React.createElement('button', {
+          key: 'done-btn',
+          className: 'done-button',
+          onClick: handleDone
+        }, [
+          React.createElement('svg', {
+            key: 'icon',
+            viewBox: '0 0 24 24',
+            fill: 'none',
+            stroke: 'currentColor',
+            strokeWidth: 2
+          }, React.createElement('polyline', { points: '20 6 9 17 4 12' })),
+          'Done'
+        ]),
+
+        // TLDraw
+        React.createElement(Tldraw, {
+          key: 'tldraw',
+          store: store,
+          onMount: handleMount,
+          autoFocus: true
+        })
+      ]);
+    }
+
+    // Render app
+    const root = document.getElementById('root');
+    ReactDOM.createRoot(root).render(React.createElement(CanvasEditorApp));
+
+    // Signal ready to parent
+    sendToParent('ready');
+  </script>
+</body>
+</html>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ mod file_locking;
 mod macos;
 
 use window_manager::{open_workspace_window, open_preferences_window, open_launcher_window};
-use tauri::Manager;
+use tauri::{Manager, Listener, Emitter};
 use tauri_plugin_store::{StoreBuilder, JsonValue};
 use std::path::PathBuf;
 

--- a/src/core/canvas/fragment-manager.js
+++ b/src/core/canvas/fragment-manager.js
@@ -1,0 +1,347 @@
+import { invoke } from '@tauri-apps/api/core';
+import { isValidFilePath } from '../security/index.js';
+
+/**
+ * Canvas Fragment Manager
+ * Handles inline canvas fragments stored in .lokus/canvas-fragments/
+ * Fragments are small TLDraw canvases embedded directly in markdown documents
+ */
+
+export class CanvasFragmentManager {
+  constructor() {
+    this.fragmentCache = new Map();
+    this.saveQueue = new Map();
+    this.loadQueue = new Map();
+  }
+
+  /**
+   * Get the fragments directory path for a workspace
+   * @param {string} workspacePath - Path to the workspace
+   * @returns {string} - Path to fragments directory
+   */
+  getFragmentsDir(workspacePath) {
+    return `${workspacePath}/.lokus/canvas-fragments`;
+  }
+
+  /**
+   * Get the full path for a fragment file
+   * @param {string} workspacePath - Path to the workspace
+   * @param {string} fragmentId - UUID of the fragment
+   * @returns {string} - Full path to fragment file
+   */
+  getFragmentPath(workspacePath, fragmentId) {
+    return `${this.getFragmentsDir(workspacePath)}/${fragmentId}.json`;
+  }
+
+  /**
+   * Ensure the fragments directory exists
+   * @param {string} workspacePath - Path to the workspace
+   * @returns {Promise<void>}
+   */
+  async ensureFragmentsDir(workspacePath) {
+    try {
+      const fragmentsDir = this.getFragmentsDir(workspacePath);
+
+      // Create directories recursively (creates .lokus and canvas-fragments)
+      try {
+        await invoke('create_directory', { path: fragmentsDir, recursive: true });
+      } catch {
+        // Directory might already exist
+      }
+    } catch (error) {
+      console.error('[Fragment Manager] Error creating directories:', error.message);
+    }
+  }
+
+  /**
+   * Generate a new UUID for a fragment
+   * @returns {string} - UUID v4
+   */
+  generateFragmentId() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  /**
+   * Create a new empty fragment
+   * @param {string} workspacePath - Path to the workspace
+   * @param {number} width - Canvas width (default 600)
+   * @param {number} height - Canvas height (default 400)
+   * @returns {Promise<{fragmentId: string, data: Object}>} - New fragment info
+   */
+  async createFragment(workspacePath, width = 600, height = 400) {
+    await this.ensureFragmentsDir(workspacePath);
+
+    const fragmentId = this.generateFragmentId();
+    const data = this.createEmptyFragmentData(width, height);
+
+    await this.saveFragment(workspacePath, fragmentId, data);
+
+    return { fragmentId, data };
+  }
+
+  /**
+   * Create empty TLDraw fragment data
+   * @param {number} width - Canvas width
+   * @param {number} height - Canvas height
+   * @returns {Object} - Empty TLDraw snapshot
+   */
+  createEmptyFragmentData(width = 600, height = 400) {
+    return {
+      records: [],
+      schema: {
+        schemaVersion: 1,
+        storeVersion: 4,
+        recordVersions: {
+          asset: { version: 1, subTypeKey: 'type', subTypeVersions: { image: 2, video: 2, bookmark: 0 } },
+          camera: { version: 1 },
+          document: { version: 2 },
+          instance: { version: 22 },
+          instance_page_state: { version: 5 },
+          page: { version: 1 },
+          shape: {
+            version: 3,
+            subTypeKey: 'type',
+            subTypeVersions: {
+              group: 0, geo: 1, arrow: 1, highlight: 0, embed: 4, image: 2, video: 1, text: 1, draw: 1
+            }
+          },
+          instance_presence: { version: 5 },
+          pointer: { version: 1 }
+        }
+      },
+      metadata: {
+        width,
+        height,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString()
+      }
+    };
+  }
+
+  /**
+   * Load fragment data from file with queue management
+   * @param {string} workspacePath - Path to the workspace
+   * @param {string} fragmentId - UUID of the fragment
+   * @returns {Promise<Object>} - Fragment data
+   */
+  async loadFragment(workspacePath, fragmentId) {
+    const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+
+    // Prevent concurrent loads of same fragment
+    if (this.loadQueue.has(fragmentPath)) {
+      return this.loadQueue.get(fragmentPath);
+    }
+
+    const loadPromise = this._loadFragmentInternal(workspacePath, fragmentId);
+    this.loadQueue.set(fragmentPath, loadPromise);
+
+    try {
+      const result = await loadPromise;
+      return result;
+    } finally {
+      this.loadQueue.delete(fragmentPath);
+    }
+  }
+
+  /**
+   * Internal load implementation
+   * @private
+   */
+  async _loadFragmentInternal(workspacePath, fragmentId) {
+    try {
+      const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+
+      // Validate path
+      if (!isValidFilePath(fragmentPath)) {
+        throw new Error('Invalid fragment path');
+      }
+
+      // Wait for any pending saves
+      if (this.saveQueue.has(fragmentPath)) {
+        await this.saveQueue.get(fragmentPath);
+      }
+
+      // Clear cache before loading
+      this.fragmentCache.delete(fragmentPath);
+
+      const content = await invoke('read_file_content', { path: fragmentPath });
+      let fragmentData;
+
+      try {
+        fragmentData = JSON.parse(content);
+
+        // Ensure schema exists
+        if (!fragmentData.schema) {
+          fragmentData.schema = this.createEmptyFragmentData().schema;
+        }
+      } catch (parseError) {
+        console.error('[Fragment Manager] Parse error:', parseError.message);
+        fragmentData = this.createEmptyFragmentData();
+      }
+
+      // Cache the loaded data
+      this.fragmentCache.set(fragmentPath, fragmentData);
+
+      return fragmentData;
+    } catch (error) {
+      console.error('[Fragment Manager] Load error:', error.message);
+      // Return empty fragment data on error
+      return this.createEmptyFragmentData();
+    }
+  }
+
+  /**
+   * Save fragment data to file with queue management
+   * @param {string} workspacePath - Path to the workspace
+   * @param {string} fragmentId - UUID of the fragment
+   * @param {Object} data - Fragment data to save
+   * @returns {Promise<void>}
+   */
+  async saveFragment(workspacePath, fragmentId, data) {
+    const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+
+    // Prevent concurrent saves
+    if (this.saveQueue.has(fragmentPath)) {
+      await this.saveQueue.get(fragmentPath);
+    }
+
+    const savePromise = this._saveFragmentInternal(workspacePath, fragmentId, data);
+    this.saveQueue.set(fragmentPath, savePromise);
+
+    try {
+      await savePromise;
+    } finally {
+      this.saveQueue.delete(fragmentPath);
+    }
+  }
+
+  /**
+   * Internal save implementation
+   * @private
+   */
+  async _saveFragmentInternal(workspacePath, fragmentId, data) {
+    try {
+      await this.ensureFragmentsDir(workspacePath);
+
+      const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+
+      // Validate path
+      if (!isValidFilePath(fragmentPath)) {
+        throw new Error('Invalid fragment path');
+      }
+
+      // Update modified timestamp
+      if (data.metadata) {
+        data.metadata.modified = new Date().toISOString();
+      }
+
+      const content = JSON.stringify(data, null, 2);
+
+      await invoke('write_file_content', {
+        path: fragmentPath,
+        content
+      });
+
+      // Clear cache
+      this.fragmentCache.delete(fragmentPath);
+    } catch (error) {
+      console.error('[Fragment Manager] Save error:', error.message);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a fragment file
+   * @param {string} workspacePath - Path to the workspace
+   * @param {string} fragmentId - UUID of the fragment
+   * @returns {Promise<boolean>} - True if deleted successfully
+   */
+  async deleteFragment(workspacePath, fragmentId) {
+    try {
+      const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+
+      await invoke('delete_file', { path: fragmentPath });
+      this.fragmentCache.delete(fragmentPath);
+
+      return true;
+    } catch (error) {
+      console.error('[Fragment Manager] Delete error:', error.message);
+      return false;
+    }
+  }
+
+  /**
+   * Check if a fragment exists
+   * @param {string} workspacePath - Path to the workspace
+   * @param {string} fragmentId - UUID of the fragment
+   * @returns {Promise<boolean>}
+   */
+  async fragmentExists(workspacePath, fragmentId) {
+    try {
+      const fragmentPath = this.getFragmentPath(workspacePath, fragmentId);
+      await invoke('read_file_content', { path: fragmentPath });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * List all fragment IDs in a workspace
+   * @param {string} workspacePath - Path to the workspace
+   * @returns {Promise<string[]>} - Array of fragment IDs
+   */
+  async listFragments(workspacePath) {
+    try {
+      const fragmentsDir = this.getFragmentsDir(workspacePath);
+      const files = await invoke('list_directory', { path: fragmentsDir });
+
+      return files
+        .filter(f => f.endsWith('.json'))
+        .map(f => f.replace('.json', ''));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Clear all cached fragments
+   */
+  clearCache() {
+    this.fragmentCache.clear();
+  }
+
+  /**
+   * Get queue status for debugging
+   * @returns {Object}
+   */
+  getQueueStatus() {
+    return {
+      activeLoads: Array.from(this.loadQueue.keys()),
+      activeSaves: Array.from(this.saveQueue.keys()),
+      cachedFragments: Array.from(this.fragmentCache.keys())
+    };
+  }
+
+  /**
+   * Wait for all pending operations
+   * @returns {Promise<void>}
+   */
+  async waitForPendingOperations() {
+    const allPromises = [
+      ...Array.from(this.saveQueue.values()),
+      ...Array.from(this.loadQueue.values())
+    ];
+
+    if (allPromises.length > 0) {
+      await Promise.all(allPromises);
+    }
+  }
+}
+
+// Create singleton instance
+export const fragmentManager = new CanvasFragmentManager();

--- a/src/core/canvas/preview-generator.js
+++ b/src/core/canvas/preview-generator.js
@@ -105,6 +105,44 @@ export async function generatePreview(canvasPath) {
 }
 
 /**
+ * Generate SVG preview from TLDraw snapshot data directly (no file I/O)
+ * Used for embedded canvas fragments where we already have the data in memory
+ *
+ * @param {Object} tldrawSnapshot - TLDraw snapshot data (records array or document.store format)
+ * @returns {string} SVG data URL (data:image/svg+xml;base64,...)
+ */
+export function generatePreviewFromData(tldrawSnapshot) {
+  try {
+    // Validate input
+    if (!tldrawSnapshot || typeof tldrawSnapshot !== 'object') {
+      return svgToDataUrl(createEmptyCanvasSvg());
+    }
+
+    // Parse shapes from snapshot
+    const shapes = extractShapes(tldrawSnapshot);
+
+    // Handle empty canvas
+    if (shapes.length === 0) {
+      const emptySvg = createEmptyCanvasSvg();
+      return svgToDataUrl(emptySvg);
+    }
+
+    // Calculate canvas bounds
+    const bounds = calculateBounds(shapes);
+
+    // Generate SVG from shapes
+    const svg = generateSvgFromShapes(shapes, bounds);
+
+    return svgToDataUrl(svg);
+
+  } catch (error) {
+    console.error('[Preview Generator] Error generating preview from data:', error.message);
+    const errorSvg = createErrorSvg(error.message);
+    return svgToDataUrl(errorSvg);
+  }
+}
+
+/**
  * Get cached preview if available and not expired
  *
  * @param {string} canvasPath - Absolute path to the .canvas file

--- a/src/core/export/markdown-exporter.js
+++ b/src/core/export/markdown-exporter.js
@@ -266,6 +266,16 @@ export class MarkdownExporter {
             }
             break;
 
+          // Embedded Canvas (inline TLDraw)
+          case 'embedded-canvas':
+            const fragmentId = child.getAttribute('data-fragment-id') || '';
+            const canvasWidth = child.getAttribute('data-width') || '600';
+            const canvasHeight = child.getAttribute('data-height') || '400';
+            if (fragmentId) {
+              result += `\n![canvas:${fragmentId}:${canvasWidth}x${canvasHeight}]\n\n`;
+            }
+            break;
+
           // Line breaks
           case 'br':
             result += '\n';

--- a/src/editor/components/Editor.jsx
+++ b/src/editor/components/Editor.jsx
@@ -37,6 +37,7 @@ import CodeBlockIndent from "../extensions/CodeBlockIndent.js";
 import Callout from "../extensions/Callout.js";
 import Folding from "../extensions/Folding.js";
 import MermaidDiagram from "../extensions/MermaidDiagram.jsx";
+import EmbeddedCanvas from "../extensions/EmbeddedCanvas.jsx";
 import CanvasLink from '../extensions/CanvasLink.js';
 import liveEditorSettings from "../../core/editor/live-settings.js";
 import WikiLinkModal from "../../components/WikiLinkModal.jsx";
@@ -274,6 +275,8 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
     // Mermaid diagrams
     exts.push(MermaidDiagram);
 
+    // Embedded Canvas (inline TLDraw)
+    exts.push(EmbeddedCanvas);
 
     // Add plugin extensions
     exts.push(...pluginExtensions);

--- a/src/editor/extensions/EmbeddedCanvas.jsx
+++ b/src/editor/extensions/EmbeddedCanvas.jsx
@@ -1,0 +1,380 @@
+import { mergeAttributes, Node, InputRule } from '@tiptap/core'
+import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { fragmentManager } from '../../core/canvas/fragment-manager.js'
+import { generatePreviewFromData } from '../../core/canvas/preview-generator.js'
+import { useTheme } from '../../hooks/theme.jsx'
+import { Pencil, Check, Trash2, GripVertical } from 'lucide-react'
+
+// Constants
+const EMBEDDED_CANVAS_CONSTANTS = {
+  DEFAULT_WIDTH: 600,
+  DEFAULT_HEIGHT: 400,
+  MIN_WIDTH: 200,
+  MIN_HEIGHT: 150,
+  MAX_WIDTH: 1200,
+  MAX_HEIGHT: 800
+}
+
+// Input rule regex: matches ![canvas] or ![canvas:600x400]
+const CANVAS_INPUT_REGEX = /!\[canvas(?::(\d+)x(\d+))?\]$/
+
+/**
+ * Embedded Canvas TipTap Extension
+ * Creates inline TLDraw canvases with iframe isolation for performance
+ */
+const EmbeddedCanvas = Node.create({
+  name: 'embeddedCanvas',
+  group: 'block',
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      fragmentId: {
+        default: null,
+      },
+      width: {
+        default: EMBEDDED_CANVAS_CONSTANTS.DEFAULT_WIDTH,
+      },
+      height: {
+        default: EMBEDDED_CANVAS_CONSTANTS.DEFAULT_HEIGHT,
+      },
+      isNew: {
+        default: false,
+      }
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'embedded-canvas',
+        getAttrs: node => ({
+          fragmentId: node.getAttribute('data-fragment-id'),
+          width: parseInt(node.getAttribute('data-width')) || EMBEDDED_CANVAS_CONSTANTS.DEFAULT_WIDTH,
+          height: parseInt(node.getAttribute('data-height')) || EMBEDDED_CANVAS_CONSTANTS.DEFAULT_HEIGHT,
+        }),
+      },
+    ]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'embedded-canvas',
+      mergeAttributes(HTMLAttributes, {
+        'data-fragment-id': node.attrs.fragmentId,
+        'data-width': node.attrs.width,
+        'data-height': node.attrs.height,
+      }),
+    ]
+  },
+
+  addInputRules() {
+    return [
+      new InputRule({
+        find: CANVAS_INPUT_REGEX,
+        handler: ({ state, range, match }) => {
+          const nodeType = state.schema.nodes.embeddedCanvas
+          if (!nodeType) return null
+
+          const width = match[1] ? parseInt(match[1]) : EMBEDDED_CANVAS_CONSTANTS.DEFAULT_WIDTH
+          const height = match[2] ? parseInt(match[2]) : EMBEDDED_CANVAS_CONSTANTS.DEFAULT_HEIGHT
+
+          const clampedWidth = Math.max(
+            EMBEDDED_CANVAS_CONSTANTS.MIN_WIDTH,
+            Math.min(EMBEDDED_CANVAS_CONSTANTS.MAX_WIDTH, width)
+          )
+          const clampedHeight = Math.max(
+            EMBEDDED_CANVAS_CONSTANTS.MIN_HEIGHT,
+            Math.min(EMBEDDED_CANVAS_CONSTANTS.MAX_HEIGHT, height)
+          )
+
+          const fragmentId = generateUUID()
+
+          const tr = state.tr.replaceRangeWith(
+            range.from,
+            range.to,
+            nodeType.create({
+              fragmentId,
+              width: clampedWidth,
+              height: clampedHeight,
+              isNew: true,
+            })
+          )
+
+          return tr
+        },
+      }),
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(EmbeddedCanvasComponent)
+  },
+})
+
+function generateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+/**
+ * Embedded Canvas React Component
+ * Uses iframe isolation for smooth TLDraw performance
+ */
+function EmbeddedCanvasComponent({ node, updateAttributes, deleteNode, selected }) {
+  const { fragmentId, width, height, isNew } = node.attrs
+  const { theme } = useTheme()
+
+  const [mode, setMode] = useState('preview') // 'preview' | 'editing'
+  const [previewUrl, setPreviewUrl] = useState(null)
+  const [fragmentData, setFragmentData] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [iframeReady, setIframeReady] = useState(false)
+
+  const containerRef = useRef(null)
+  const iframeRef = useRef(null)
+  const isMountedRef = useRef(true)
+
+  const workspacePath = globalThis.__LOKUS_WORKSPACE_PATH__ || ''
+  const isDarkMode = theme?.name === 'dark' || theme?.mode === 'dark'
+
+  // Load fragment data and generate preview on mount
+  useEffect(() => {
+    if (!fragmentId || !workspacePath) return
+
+    const loadAndPreview = async () => {
+      setIsLoading(true)
+
+      try {
+        let data
+        if (isNew) {
+          data = fragmentManager.createEmptyFragmentData(width, height)
+          await fragmentManager.saveFragment(workspacePath, fragmentId, data)
+          updateAttributes({ isNew: false })
+        } else {
+          data = await fragmentManager.loadFragment(workspacePath, fragmentId)
+        }
+
+        setFragmentData(data)
+        const preview = generatePreviewFromData(data)
+        setPreviewUrl(preview)
+
+      } catch (error) {
+        console.error('[EmbeddedCanvas] Failed to load fragment:', error)
+        const emptyData = fragmentManager.createEmptyFragmentData(width, height)
+        setFragmentData(emptyData)
+        setPreviewUrl(generatePreviewFromData(emptyData))
+      } finally {
+        if (isMountedRef.current) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadAndPreview()
+  }, [fragmentId, workspacePath, isNew, width, height])
+
+  // Listen for messages from iframe
+  useEffect(() => {
+    const handleMessage = async (event) => {
+      // Only handle messages from our iframe
+      if (iframeRef.current && event.source !== iframeRef.current.contentWindow) {
+        return
+      }
+
+      const { type, data } = event.data || {}
+
+      switch (type) {
+        case 'ready':
+          setIframeReady(true)
+          // Send fragment data to iframe
+          if (iframeRef.current && fragmentData) {
+            iframeRef.current.contentWindow.postMessage({
+              type: 'load',
+              data: fragmentData
+            }, '*')
+            iframeRef.current.contentWindow.postMessage({
+              type: 'theme',
+              data: { dark: isDarkMode }
+            }, '*')
+          }
+          break
+
+        case 'save':
+          // Auto-save from iframe
+          if (data && workspacePath && fragmentId) {
+            try {
+              await fragmentManager.saveFragment(workspacePath, fragmentId, data)
+              setFragmentData(data)
+            } catch (error) {
+              console.error('[EmbeddedCanvas] Auto-save failed:', error)
+            }
+          }
+          break
+
+        case 'done':
+          // User clicked Done - exit edit mode
+          if (fragmentData) {
+            const newPreview = generatePreviewFromData(fragmentData)
+            setPreviewUrl(newPreview)
+          }
+          setMode('preview')
+          setIframeReady(false)
+          break
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [fragmentData, workspacePath, fragmentId, isDarkMode])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  // Enter edit mode
+  const enterEditMode = useCallback(() => {
+    setMode('editing')
+    setIframeReady(false)
+  }, [])
+
+  // Handle delete
+  const handleDelete = useCallback(async () => {
+    if (workspacePath && fragmentId) {
+      await fragmentManager.deleteFragment(workspacePath, fragmentId)
+    }
+    deleteNode()
+  }, [workspacePath, fragmentId, deleteNode])
+
+  return (
+    <NodeViewWrapper
+      ref={containerRef}
+      className={`embedded-canvas-wrapper relative my-4 rounded-lg border-2 transition-all ${
+        selected ? 'border-blue-500' : 'border-transparent hover:border-gray-300'
+      } ${mode === 'editing' ? 'ring-2 ring-blue-400' : ''}`}
+      style={{
+        width: width + 4,
+        backgroundColor: isDarkMode ? '#1e1e2e' : '#f5f5f5',
+      }}
+      data-drag-handle
+    >
+      {/* Toolbar - only show in preview mode */}
+      {mode === 'preview' && (
+        <div
+          className="absolute top-2 right-2 flex gap-1 z-10"
+          style={{
+            opacity: selected ? 1 : 0,
+            transition: 'opacity 0.2s',
+          }}
+          onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+          onMouseLeave={(e) => e.currentTarget.style.opacity = selected ? '1' : '0'}
+        >
+          <button
+            onClick={enterEditMode}
+            className="p-1.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:opacity-80"
+            title="Edit canvas"
+          >
+            <Pencil className="w-4 h-4" />
+          </button>
+
+          <button
+            onClick={handleDelete}
+            className="p-1.5 rounded bg-red-100 dark:bg-red-900 text-red-600 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-800"
+            title="Delete canvas"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Drag handle */}
+      {mode === 'preview' && (
+        <div
+          className="absolute top-2 left-2 z-10 cursor-grab p-1 rounded bg-gray-200 dark:bg-gray-700"
+          style={{
+            opacity: selected ? 0.8 : 0,
+            transition: 'opacity 0.2s',
+          }}
+          data-drag-handle
+        >
+          <GripVertical className="w-4 h-4 text-gray-500" />
+        </div>
+      )}
+
+      {/* Canvas container */}
+      <div
+        className="overflow-hidden rounded-lg"
+        style={{ width, height }}
+      >
+        {/* Loading state */}
+        {isLoading && (
+          <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
+            <span className="text-gray-500">Loading canvas...</span>
+          </div>
+        )}
+
+        {/* Preview mode - static SVG image */}
+        {!isLoading && mode === 'preview' && (
+          <div
+            className="w-full h-full cursor-pointer relative"
+            onClick={enterEditMode}
+          >
+            {previewUrl ? (
+              <img
+                src={previewUrl}
+                alt="Canvas preview"
+                className="w-full h-full object-contain"
+                style={{ backgroundColor: isDarkMode ? '#1e1e2e' : '#f5f5f5' }}
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">
+                <span className="text-gray-500">Empty canvas</span>
+              </div>
+            )}
+            <div className="absolute inset-0 flex items-center justify-center bg-transparent hover:bg-black/5 transition-colors">
+              <span
+                className="px-3 py-1.5 rounded-full text-sm font-medium opacity-0 hover:opacity-100 transition-opacity"
+                style={{
+                  backgroundColor: isDarkMode ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.8)',
+                  color: isDarkMode ? '#1e1e2e' : '#fff',
+                }}
+              >
+                Click to edit
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Edit mode - iframe with TLDraw */}
+        {!isLoading && mode === 'editing' && (
+          <div className="w-full h-full relative">
+            {!iframeReady && (
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800 z-10">
+                <span className="text-gray-500">Loading editor...</span>
+              </div>
+            )}
+            <iframe
+              ref={iframeRef}
+              src="/canvas-editor.html"
+              className="w-full h-full border-0"
+              style={{ opacity: iframeReady ? 1 : 0 }}
+              title="Canvas Editor"
+            />
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+export default EmbeddedCanvas

--- a/src/plugins/api/EditorAPI.js
+++ b/src/plugins/api/EditorAPI.js
@@ -961,6 +961,12 @@ export class EditorPluginAPI extends EventEmitter {
    */
   setEditorInstance(editor) {
     this.editorInstance = editor
+
+    // Handle null editor (during cleanup/unmount)
+    if (!editor) {
+      return
+    }
+
     this.emit('editor-attached', { editor })
 
     // Listen for editor updates

--- a/tests/unit/canvas/fragment-manager.test.js
+++ b/tests/unit/canvas/fragment-manager.test.js
@@ -1,0 +1,333 @@
+/**
+ * Tests for Canvas Fragment Manager
+ * Tests fragment storage operations for embedded canvases
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock Tauri invoke
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn()
+}));
+
+// Import after mocking
+import { CanvasFragmentManager, fragmentManager } from '../../../src/core/canvas/fragment-manager.js';
+import { invoke } from '@tauri-apps/api/core';
+
+describe('Canvas Fragment Manager', () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new CanvasFragmentManager();
+    vi.clearAllMocks();
+  });
+
+  describe('Path Generation', () => {
+    it('should generate correct fragments directory path', () => {
+      const workspacePath = '/Users/test/workspace';
+      const dir = manager.getFragmentsDir(workspacePath);
+
+      expect(dir).toBe('/Users/test/workspace/.lokus/canvas-fragments');
+    });
+
+    it('should generate correct fragment file path', () => {
+      const workspacePath = '/Users/test/workspace';
+      const fragmentId = 'abc123-def456';
+      const path = manager.getFragmentPath(workspacePath, fragmentId);
+
+      expect(path).toBe('/Users/test/workspace/.lokus/canvas-fragments/abc123-def456.json');
+    });
+  });
+
+  describe('Fragment ID Generation', () => {
+    it('should generate valid UUID v4', () => {
+      const id = manager.generateFragmentId();
+
+      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it('should generate unique IDs', () => {
+      const ids = new Set();
+      for (let i = 0; i < 100; i++) {
+        ids.add(manager.generateFragmentId());
+      }
+
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe('Empty Fragment Data', () => {
+    it('should create empty fragment data with default dimensions', () => {
+      const data = manager.createEmptyFragmentData();
+
+      expect(data.records).toEqual([]);
+      expect(data.schema).toBeDefined();
+      expect(data.schema.schemaVersion).toBe(1);
+      expect(data.metadata.width).toBe(600);
+      expect(data.metadata.height).toBe(400);
+    });
+
+    it('should create empty fragment data with custom dimensions', () => {
+      const data = manager.createEmptyFragmentData(800, 600);
+
+      expect(data.metadata.width).toBe(800);
+      expect(data.metadata.height).toBe(600);
+    });
+
+    it('should include timestamp in metadata', () => {
+      const before = new Date().toISOString();
+      const data = manager.createEmptyFragmentData();
+      const after = new Date().toISOString();
+
+      expect(data.metadata.created).toBeDefined();
+      expect(data.metadata.modified).toBeDefined();
+      expect(new Date(data.metadata.created).getTime()).toBeGreaterThanOrEqual(new Date(before).getTime());
+      expect(new Date(data.metadata.created).getTime()).toBeLessThanOrEqual(new Date(after).getTime());
+    });
+
+    it('should include TLDraw schema with all shape types', () => {
+      const data = manager.createEmptyFragmentData();
+
+      expect(data.schema.recordVersions.shape).toBeDefined();
+      expect(data.schema.recordVersions.shape.subTypeVersions).toHaveProperty('draw');
+      expect(data.schema.recordVersions.shape.subTypeVersions).toHaveProperty('geo');
+      expect(data.schema.recordVersions.shape.subTypeVersions).toHaveProperty('text');
+    });
+  });
+
+  describe('Load Fragment', () => {
+    it('should load fragment from file', async () => {
+      const mockData = {
+        records: [{ id: 'shape:1', type: 'draw' }],
+        schema: { schemaVersion: 1 },
+        metadata: { width: 600, height: 400 }
+      };
+
+      invoke.mockResolvedValue(JSON.stringify(mockData));
+
+      const result = await manager.loadFragment('/workspace', 'fragment-123');
+
+      expect(invoke).toHaveBeenCalledWith('read_file_content', {
+        path: '/workspace/.lokus/canvas-fragments/fragment-123.json'
+      });
+      expect(result.records).toEqual(mockData.records);
+    });
+
+    it('should return empty fragment on file not found', async () => {
+      invoke.mockRejectedValue(new Error('File not found'));
+
+      const result = await manager.loadFragment('/workspace', 'nonexistent');
+
+      expect(result.records).toEqual([]);
+      expect(result.schema).toBeDefined();
+    });
+
+    it('should add default schema if missing', async () => {
+      const mockData = {
+        records: [{ id: 'shape:1' }]
+        // No schema
+      };
+
+      invoke.mockResolvedValue(JSON.stringify(mockData));
+
+      const result = await manager.loadFragment('/workspace', 'fragment-123');
+
+      expect(result.schema).toBeDefined();
+      expect(result.schema.schemaVersion).toBe(1);
+    });
+
+    it('should return empty fragment on parse error', async () => {
+      invoke.mockResolvedValue('invalid json {');
+
+      const result = await manager.loadFragment('/workspace', 'bad-json');
+
+      expect(result.records).toEqual([]);
+    });
+
+    it('should cache loaded fragment', async () => {
+      const mockData = {
+        records: [],
+        schema: { schemaVersion: 1 },
+        metadata: {}
+      };
+
+      invoke.mockResolvedValue(JSON.stringify(mockData));
+
+      await manager.loadFragment('/workspace', 'cached');
+
+      const cached = manager.fragmentCache.get('/workspace/.lokus/canvas-fragments/cached.json');
+      expect(cached).toBeDefined();
+    });
+  });
+
+  describe('Save Fragment', () => {
+    it('should save fragment to file', async () => {
+      invoke.mockResolvedValue(undefined);
+
+      const data = {
+        records: [{ id: 'shape:1' }],
+        schema: { schemaVersion: 1 },
+        metadata: { width: 600, height: 400 }
+      };
+
+      await manager.saveFragment('/workspace', 'fragment-123', data);
+
+      expect(invoke).toHaveBeenCalledWith('write_file_content', expect.objectContaining({
+        path: '/workspace/.lokus/canvas-fragments/fragment-123.json'
+      }));
+    });
+
+    it('should update modified timestamp on save', async () => {
+      invoke.mockResolvedValue(undefined);
+
+      const data = {
+        records: [],
+        schema: { schemaVersion: 1 },
+        metadata: { width: 600, height: 400, created: '2024-01-01T00:00:00.000Z' }
+      };
+
+      await manager.saveFragment('/workspace', 'fragment-123', data);
+
+      // Check that the saved content has updated modified timestamp
+      const savedContent = JSON.parse(invoke.mock.calls.find(c => c[0] === 'write_file_content')[1].content);
+      expect(new Date(savedContent.metadata.modified).getTime()).toBeGreaterThan(new Date('2024-01-01').getTime());
+    });
+
+    it('should ensure directories exist before save', async () => {
+      invoke.mockResolvedValue(undefined);
+
+      const data = manager.createEmptyFragmentData();
+
+      await manager.saveFragment('/workspace', 'new-fragment', data);
+
+      // Check that create_directory was called for .lokus and canvas-fragments
+      const createDirCalls = invoke.mock.calls.filter(c => c[0] === 'create_directory');
+      expect(createDirCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Delete Fragment', () => {
+    it('should delete fragment file', async () => {
+      invoke.mockResolvedValue(undefined);
+
+      const result = await manager.deleteFragment('/workspace', 'to-delete');
+
+      expect(invoke).toHaveBeenCalledWith('delete_file', {
+        path: '/workspace/.lokus/canvas-fragments/to-delete.json'
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return false on delete error', async () => {
+      invoke.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await manager.deleteFragment('/workspace', 'protected');
+
+      expect(result).toBe(false);
+    });
+
+    it('should clear cache on delete', async () => {
+      // First cache something
+      manager.fragmentCache.set('/workspace/.lokus/canvas-fragments/cached.json', {});
+
+      invoke.mockResolvedValue(undefined);
+
+      await manager.deleteFragment('/workspace', 'cached');
+
+      expect(manager.fragmentCache.has('/workspace/.lokus/canvas-fragments/cached.json')).toBe(false);
+    });
+  });
+
+  describe('Fragment Exists', () => {
+    it('should return true for existing fragment', async () => {
+      invoke.mockResolvedValue('{}');
+
+      const exists = await manager.fragmentExists('/workspace', 'exists');
+
+      expect(exists).toBe(true);
+    });
+
+    it('should return false for non-existing fragment', async () => {
+      invoke.mockRejectedValue(new Error('File not found'));
+
+      const exists = await manager.fragmentExists('/workspace', 'missing');
+
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe('List Fragments', () => {
+    it('should return list of fragment IDs', async () => {
+      invoke.mockResolvedValue([
+        'abc-123.json',
+        'def-456.json',
+        'ghi-789.json'
+      ]);
+
+      const ids = await manager.listFragments('/workspace');
+
+      expect(ids).toEqual(['abc-123', 'def-456', 'ghi-789']);
+    });
+
+    it('should return empty array on error', async () => {
+      invoke.mockRejectedValue(new Error('Directory not found'));
+
+      const ids = await manager.listFragments('/workspace');
+
+      expect(ids).toEqual([]);
+    });
+
+    it('should filter out non-json files', async () => {
+      invoke.mockResolvedValue([
+        'abc.json',
+        'def.json',
+        '.DS_Store',
+        'readme.txt'
+      ]);
+
+      const ids = await manager.listFragments('/workspace');
+
+      expect(ids).toEqual(['abc', 'def']);
+    });
+  });
+
+  describe('Queue Management', () => {
+    it('should prevent concurrent loads of same fragment', async () => {
+      let resolveFirst;
+      const firstPromise = new Promise(r => { resolveFirst = r; });
+
+      invoke.mockImplementation(() => firstPromise);
+
+      // Start two loads at the same time
+      const load1 = manager.loadFragment('/workspace', 'concurrent');
+      const load2 = manager.loadFragment('/workspace', 'concurrent');
+
+      // Both should return the same promise
+      expect(manager.loadQueue.size).toBe(1);
+
+      // Resolve the load
+      resolveFirst('{}');
+
+      await Promise.all([load1, load2]);
+
+      // Queue should be cleared
+      expect(manager.loadQueue.size).toBe(0);
+    });
+
+    it('should return queue status', () => {
+      const status = manager.getQueueStatus();
+
+      expect(status).toHaveProperty('activeLoads');
+      expect(status).toHaveProperty('activeSaves');
+      expect(status).toHaveProperty('cachedFragments');
+      expect(Array.isArray(status.activeLoads)).toBe(true);
+    });
+  });
+
+  describe('Singleton Instance', () => {
+    it('should export singleton instance', () => {
+      expect(fragmentManager).toBeInstanceOf(CanvasFragmentManager);
+    });
+  });
+});

--- a/tests/unit/editor/embedded-canvas.test.js
+++ b/tests/unit/editor/embedded-canvas.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests for Embedded Canvas Extension
+ * Tests the ![canvas] input rule and markdown round-trip
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MarkdownExporter } from '../../../src/core/export/markdown-exporter.js';
+
+describe('Embedded Canvas', () => {
+  describe('Input Rule Pattern', () => {
+    // Test the regex pattern used in the input rule
+    const CANVAS_INPUT_REGEX = /!\[canvas(?::(\d+)x(\d+))?\]$/;
+
+    it('should match ![canvas] without dimensions', () => {
+      const match = '![canvas]'.match(CANVAS_INPUT_REGEX);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBeUndefined(); // No width
+      expect(match[2]).toBeUndefined(); // No height
+    });
+
+    it('should match ![canvas:600x400] with dimensions', () => {
+      const match = '![canvas:600x400]'.match(CANVAS_INPUT_REGEX);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('600');
+      expect(match[2]).toBe('400');
+    });
+
+    it('should match ![canvas:1200x800] with large dimensions', () => {
+      const match = '![canvas:1200x800]'.match(CANVAS_INPUT_REGEX);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('1200');
+      expect(match[2]).toBe('800');
+    });
+
+    it('should match at end of text', () => {
+      const match = 'Some text before ![canvas]'.match(CANVAS_INPUT_REGEX);
+      expect(match).not.toBeNull();
+    });
+
+    it('should match at end with dimensions', () => {
+      const match = 'Draw here: ![canvas:400x300]'.match(CANVAS_INPUT_REGEX);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('400');
+      expect(match[2]).toBe('300');
+    });
+
+    it('should not match ![canvas] in middle of line', () => {
+      const match = '![canvas] and more text'.match(CANVAS_INPUT_REGEX);
+      expect(match).toBeNull();
+    });
+
+    it('should not match regular image syntax', () => {
+      const match = '![alt text](http://example.com/img.png)'.match(CANVAS_INPUT_REGEX);
+      expect(match).toBeNull();
+    });
+
+    it('should not match wiki embed syntax', () => {
+      const match = '![[Note Name]]'.match(CANVAS_INPUT_REGEX);
+      expect(match).toBeNull();
+    });
+
+    it('should not match canvas link syntax', () => {
+      const match = '![My Canvas]'.match(CANVAS_INPUT_REGEX);
+      // This should not match because "My Canvas" doesn't start with "canvas:"
+      expect(match).toBeNull();
+    });
+  });
+
+  describe('Dimension Clamping', () => {
+    const MIN_WIDTH = 200;
+    const MIN_HEIGHT = 150;
+    const MAX_WIDTH = 1200;
+    const MAX_HEIGHT = 800;
+
+    function clampDimensions(width, height) {
+      return {
+        width: Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, width)),
+        height: Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, height))
+      };
+    }
+
+    it('should clamp too-small width', () => {
+      const { width } = clampDimensions(100, 400);
+      expect(width).toBe(MIN_WIDTH);
+    });
+
+    it('should clamp too-small height', () => {
+      const { height } = clampDimensions(600, 50);
+      expect(height).toBe(MIN_HEIGHT);
+    });
+
+    it('should clamp too-large width', () => {
+      const { width } = clampDimensions(2000, 400);
+      expect(width).toBe(MAX_WIDTH);
+    });
+
+    it('should clamp too-large height', () => {
+      const { height } = clampDimensions(600, 1500);
+      expect(height).toBe(MAX_HEIGHT);
+    });
+
+    it('should not change valid dimensions', () => {
+      const { width, height } = clampDimensions(600, 400);
+      expect(width).toBe(600);
+      expect(height).toBe(400);
+    });
+  });
+
+  describe('Markdown Export', () => {
+    let exporter;
+
+    beforeEach(() => {
+      exporter = new MarkdownExporter();
+    });
+
+    it('should export embedded-canvas to ![canvas:uuid:WxH] format', () => {
+      const html = '<p><embedded-canvas data-fragment-id="abc-123" data-width="600" data-height="400"></embedded-canvas></p>';
+      const markdown = exporter.export(html);
+
+      expect(markdown).toContain('![canvas:abc-123:600x400]');
+    });
+
+    it('should export with custom dimensions', () => {
+      const html = '<embedded-canvas data-fragment-id="def-456" data-width="800" data-height="600"></embedded-canvas>';
+      const markdown = exporter.export(html);
+
+      expect(markdown).toContain('![canvas:def-456:800x600]');
+    });
+
+    it('should preserve fragment ID with UUID format', () => {
+      const uuid = 'a1b2c3d4-e5f6-4789-abcd-ef0123456789';
+      const html = `<embedded-canvas data-fragment-id="${uuid}" data-width="600" data-height="400"></embedded-canvas>`;
+      const markdown = exporter.export(html);
+
+      expect(markdown).toContain(`![canvas:${uuid}:600x400]`);
+    });
+
+    it('should handle multiple embedded canvases', () => {
+      const html = `
+        <p>First canvas:</p>
+        <embedded-canvas data-fragment-id="canvas-1" data-width="600" data-height="400"></embedded-canvas>
+        <p>Second canvas:</p>
+        <embedded-canvas data-fragment-id="canvas-2" data-width="400" data-height="300"></embedded-canvas>
+      `;
+      const markdown = exporter.export(html);
+
+      expect(markdown).toContain('![canvas:canvas-1:600x400]');
+      expect(markdown).toContain('![canvas:canvas-2:400x300]');
+    });
+
+    it('should not export embedded canvas without fragment ID', () => {
+      const html = '<embedded-canvas data-width="600" data-height="400"></embedded-canvas>';
+      const markdown = exporter.export(html);
+
+      expect(markdown).not.toContain('![canvas:');
+    });
+  });
+
+  describe('Markdown Import Pattern', () => {
+    // Test the regex pattern used in the markdown-it plugin
+    const EMBEDDED_CANVAS_REGEX = /^canvas:([a-f0-9-]+):(\d+)x(\d+)$/;
+
+    it('should match valid embedded canvas syntax', () => {
+      const content = 'canvas:abc-123:600x400';
+      const match = content.match(EMBEDDED_CANVAS_REGEX);
+
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('abc-123');
+      expect(match[2]).toBe('600');
+      expect(match[3]).toBe('400');
+    });
+
+    it('should match UUID fragment IDs', () => {
+      const content = 'canvas:a1b2c3d4-e5f6-4789-abcd-ef0123456789:800x600';
+      const match = content.match(EMBEDDED_CANVAS_REGEX);
+
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('a1b2c3d4-e5f6-4789-abcd-ef0123456789');
+    });
+
+    it('should not match canvas links (no dimensions)', () => {
+      const content = 'My Canvas';
+      const match = content.match(EMBEDDED_CANVAS_REGEX);
+
+      expect(match).toBeNull();
+    });
+
+    it('should not match invalid fragment IDs', () => {
+      const content = 'canvas:INVALID_ID:600x400';
+      const match = content.match(EMBEDDED_CANVAS_REGEX);
+
+      expect(match).toBeNull(); // Uppercase not allowed
+    });
+  });
+
+  describe('Markdown Round-trip', () => {
+    let exporter;
+
+    beforeEach(() => {
+      exporter = new MarkdownExporter();
+    });
+
+    it('should export and format correctly for re-import', () => {
+      const html = '<embedded-canvas data-fragment-id="test-uuid-1234" data-width="600" data-height="400"></embedded-canvas>';
+      const markdown = exporter.export(html);
+
+      // The exported markdown should be in the correct format
+      expect(markdown.trim()).toBe('![canvas:test-uuid-1234:600x400]');
+    });
+
+    it('should preserve dimensions through export', () => {
+      const testCases = [
+        { width: '200', height: '150' },
+        { width: '600', height: '400' },
+        { width: '1200', height: '800' }
+      ];
+
+      for (const { width, height } of testCases) {
+        const html = `<embedded-canvas data-fragment-id="test" data-width="${width}" data-height="${height}"></embedded-canvas>`;
+        const markdown = exporter.export(html);
+
+        expect(markdown).toContain(`${width}x${height}`);
+      }
+    });
+  });
+});
+
+describe('Embedded Canvas vs Canvas Link Distinction', () => {
+  describe('Pattern Matching', () => {
+    // Embedded canvas: ![canvas:uuid:WxH] - creates inline editable canvas
+    // Canvas link: ![Canvas Name] - links to existing .canvas file
+
+    it('should distinguish embedded canvas from canvas link', () => {
+      const embeddedPattern = /!\[canvas:([a-f0-9-]+):(\d+)x(\d+)\]/;
+      const canvasLinkPattern = /!\[([^\[\]]+)\](?!\()/;
+
+      const embeddedSyntax = '![canvas:abc-123:600x400]';
+      const canvasLinkSyntax = '![My Canvas]';
+
+      // Embedded canvas should match the specific pattern
+      expect(embeddedPattern.test(embeddedSyntax)).toBe(true);
+      expect(embeddedPattern.test(canvasLinkSyntax)).toBe(false);
+
+      // Canvas link should match the general pattern but not embedded canvas format
+      // (The actual plugin checks for "canvas:" prefix to distinguish)
+    });
+
+    it('should not confuse embedded canvas with images', () => {
+      const embeddedPattern = /!\[canvas:([a-f0-9-]+):(\d+)x(\d+)\]/;
+      const imageSyntax = '![alt text](http://example.com/image.png)';
+
+      expect(embeddedPattern.test(imageSyntax)).toBe(false);
+    });
+
+    it('should not confuse embedded canvas with wiki embeds', () => {
+      const embeddedPattern = /!\[canvas:([a-f0-9-]+):(\d+)x(\d+)\]/;
+      const wikiEmbedSyntax = '![[Note Name]]';
+
+      expect(embeddedPattern.test(wikiEmbedSyntax)).toBe(false);
+    });
+  });
+});
+
+describe('UUID Generation', () => {
+  function generateUUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  it('should generate valid UUID v4 format', () => {
+    const uuid = generateUUID();
+
+    // UUID v4 format validation
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('should always have 4 in the version position', () => {
+    for (let i = 0; i < 100; i++) {
+      const uuid = generateUUID();
+      expect(uuid[14]).toBe('4');
+    }
+  });
+
+  it('should always have 8, 9, a, or b in the variant position', () => {
+    for (let i = 0; i < 100; i++) {
+      const uuid = generateUUID();
+      expect(['8', '9', 'a', 'b']).toContain(uuid[19]);
+    }
+  });
+
+  it('should generate unique IDs', () => {
+    const ids = new Set();
+    for (let i = 0; i < 1000; i++) {
+      ids.add(generateUUID());
+    }
+    expect(ids.size).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

Work in progress implementation for Issue #269: Embedded Canvas - Draw Directly in Markdown

Type `![canvas]` or `![canvas:600x400]` to create inline TLDraw canvases.

### Implemented
- Fragment storage system (`.lokus/canvas-fragments/`)
- TipTap extension with preview/edit modes
- Static SVG preview generation
- iframe isolation for TLDraw (performance optimization attempt)
- Markdown export/import support
- Auto-save with debounce
- Unit tests for fragment manager

### Known Issues
- TLDraw iframe has React module resolution issues with esm.sh CDN
- Performance testing incomplete
- Need to explore alternative approaches for iframe TLDraw loading

### Next Steps
- [ ] Fix TLDraw loading in iframe (consider bundled approach)
- [ ] Complete performance testing
- [ ] Polish UI/UX

## Test plan

- [ ] Type `![canvas]` to create embedded canvas
- [ ] Verify preview mode shows canvas content
- [ ] Verify edit mode loads TLDraw
- [ ] Test drawing performance
- [ ] Verify save/load persistence

---
🚧 **Draft PR - Not ready for review**