### PR TITLE
feat: Simplified Import Wizard + Analytics Cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,13 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_PATH_BASE64: ${{ secrets.APPLE_API_KEY_PATH_BASE64 }}
+          # Crash Reporting (Sentry/GlitchTip)
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_ENABLE_CRASH_REPORTS: 'true'
+          VITE_SENTRY_ENVIRONMENT: 'production'
+          # Analytics (Umami)
+          VITE_UMAMI_WEBSITE_ID: ${{ secrets.VITE_UMAMI_WEBSITE_ID }}
+          VITE_UMAMI_API_ENDPOINT: ${{ secrets.VITE_UMAMI_API_ENDPOINT }}
         with:
           includeUpdaterJson: true
           tagName: ${{ github.ref_name }}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -759,7 +759,8 @@ pub fn run() {
         let payload = event.payload();
         let _ = app_handle_deep_link.emit("deep-link-received", payload);
         
-        // If this is a plugin-dev link, try to open devtools
+        // If this is a plugin-dev link, try to open devtools (debug only)
+        #[cfg(debug_assertions)]
         if payload.contains("lokus://plugin-dev") {
           if let Some(window) = app_handle_deep_link.get_webview_window("main") {
             window.open_devtools();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import mcpClient from "./core/mcp/client.js";
 // Guard window access in non-Tauri environments
 import { emit } from "@tauri-apps/api/event";
 import * as Sentry from "@sentry/react";
+import analytics from "./services/analytics.js";
 
 // Simple loading spinner for Suspense fallback
 const LoadingFallback = () => (
@@ -79,10 +80,18 @@ function App() {
     }
   }, [isPrefsWindow, activePath]);
 
-  // Initialize markdown syntax config and editor config cache on app startup
+  // Initialize markdown syntax config, editor config cache, and analytics on app startup
   useEffect(() => {
+    const startTime = performance.now();
+
     markdownSyntaxConfig.init();
     editorConfigCache.init(); // Pre-load editor config to eliminate "Loading editor..." delay
+
+    // Initialize analytics and track startup time
+    analytics.initialize().then(() => {
+      const startupTime = performance.now() - startTime;
+      analytics.trackStartupTime(startupTime);
+    });
 
     // Check for updates 3 seconds after startup
     const updateTimer = setTimeout(() => {

--- a/src/bases/BasesView.jsx
+++ b/src/bases/BasesView.jsx
@@ -100,10 +100,10 @@ const BasesView = memo(function BasesView({ isVisible, onFileOpen }) {
     setRefreshKey(prev => prev + 1);
   };
 
-  // Handle view type change with analytics
+  // Handle view type change with analytics (rate limited)
   const handleViewTypeChange = (type) => {
     setViewType(type);
-    analytics.trackDatabaseView(type);
+    analytics.trackFeatureUsed('database');
   };
 
   // Handle filter rules update from BaseTableView

--- a/src/components/CommandPalette.jsx
+++ b/src/components/CommandPalette.jsx
@@ -43,6 +43,7 @@ import { saveEmailAsNote } from '../utils/emailToNote.js'
 import { invoke } from '@tauri-apps/api/core'
 import { useFolderScope } from '../contexts/FolderScopeContext'
 import { useBases } from '../bases/BasesContext.jsx'
+import analytics from '../services/analytics.js'
 import FolderSelector from './FolderSelector.jsx'
 import { useCommands, useCommandExecute } from '../hooks/useCommands.js'
 
@@ -466,6 +467,9 @@ export default function CommandPalette({
       const result = await processTemplate(template.id, {}, {
         context: {}
       })
+
+      // Track template feature usage (rate limited to once per session)
+      analytics.trackFeatureUsed('templates')
 
       // Call onShowTemplatePicker with processed content
       if (onShowTemplatePicker) {

--- a/src/components/SearchPanel.jsx
+++ b/src/components/SearchPanel.jsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { Search, X, ChevronDown, ChevronRight, Settings, Clock } from 'lucide-react'
 import { sanitizeSearchHighlight, isValidSearchQuery } from '../core/security/index.js'
 import { getFilename } from '../utils/pathUtils.js'
+import analytics from '../services/analytics.js'
 
 // Utility function to highlight search matches in text (XSS-safe)
 const highlightText = (text, query, options) => {
@@ -86,7 +87,10 @@ export default function SearchPanel({ isOpen, onClose, onFileOpen, workspacePath
       setResults(searchResults || [])
       setSelectedResultIndex(-1) // Reset selection when results change
       saveRecentSearch(searchQuery)
-      
+
+      // Track search feature usage (rate limited to once per session)
+      analytics.trackFeatureUsed('search')
+
       // Auto-expand files if there are few results
       if (searchResults && searchResults.length <= 5) {
         setExpandedFiles(new Set(searchResults.map(result => result.file)))

--- a/src/components/TemplatePicker.jsx
+++ b/src/components/TemplatePicker.jsx
@@ -12,6 +12,7 @@ import {
   X
 } from 'lucide-react';
 import { useTemplates, useTemplateProcessor } from '../hooks/useTemplates.js';
+import analytics from '../services/analytics.js';
 import {
   Dialog,
   DialogContent,
@@ -137,6 +138,9 @@ export default function TemplatePicker({
       const result = await processTemplate(template.id, {}, {
         context: {}
       });
+
+      // Track template feature usage (rate limited to once per session)
+      analytics.trackFeatureUsed('templates');
 
       onSelect?.(template, result.result || result.content || result);
       onClose?.();

--- a/src/core/plugins/PluginStateAdapter.js
+++ b/src/core/plugins/PluginStateAdapter.js
@@ -7,6 +7,7 @@ import { configManager } from "../config/ConfigManager.js";
 import { filesystemManager } from "../fs/FilesystemManager.js";
 import { PluginFileWatcher } from "./PluginFileWatcher.js";
 import { pluginEventBridge } from "../../plugins/PluginEventBridge.js";
+import analytics from "../../services/analytics.js";
 
 /**
  * PluginStateAdapter - UI State Management Facade for Plugin System
@@ -455,6 +456,9 @@ class PluginStateAdapter {
         const instance = this.pluginInstances.get(pluginId);
         if (instance && typeof instance.activate === 'function') {
           await instance.activate();
+
+          // Track plugin activation
+          analytics.trackPluginActivation(pluginId);
 
           // Emit activation event for UI components (like StatusBar)
           try {

--- a/src/hooks/theme.jsx
+++ b/src/hooks/theme.jsx
@@ -7,6 +7,7 @@ import {
   setGlobalActiveTheme,
 } from "../core/theme/manager.js";
 import { useThemeOverrides } from "../contexts/RemoteConfigContext";
+import analytics from "../services/analytics.js";
 
 // Apply server-side theme overrides as CSS variables
 const applyThemeOverrides = (overrides) => {
@@ -115,6 +116,7 @@ export function ThemeProvider({ children }) {
   const handleSetTheme = useCallback(async (newTheme) => {
     setTheme(newTheme);
     await setGlobalActiveTheme(newTheme);
+    analytics.trackThemeChange(newTheme);
   }, []);
 
   const value = {

--- a/src/views/ProfessionalGraphView.jsx
+++ b/src/views/ProfessionalGraphView.jsx
@@ -634,8 +634,8 @@ export const ProfessionalGraphView = ({ isVisible = true, workspacePath, onOpenF
     setViewMode(mode);
     setIsLayoutRunning(false); // Reset layout when switching modes
 
-    // Track graph view mode change
-    analytics.trackGraphView(mode);
+    // Track graph feature usage (rate limited to once per session)
+    analytics.trackFeatureUsed('graph');
   }, []);
 
   const handleLayoutControl = useCallback((action) => {


### PR DESCRIPTION
## Summary

- **Simplified Import Wizard**: Auto-detection of import sources with streamlined UI
- **MCP Server Tools**: Symbol shortcuts for workspace operations  
- **Analytics Cleanup**: Rate limiting and direct API calls

### Analytics Changes
- Session-based rate limiting (`trackOncePerSession`, `trackFeatureUsed`)
- Direct Umami API calls (works in Tauri WebView)
- File logging for production debugging
- Removed spammy `note_opened` tracking
- Fixed duplicate `app_startup` and `daily_note` events

## Test plan

- [x] Import wizard detects Obsidian/Notion/Markdown folders
- [x] Analytics events fire once per session per feature
- [x] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)