### PR TITLE
Fix tabs and breadcrumbs when files are deleted, renamed, or moved

### DIFF
--- a/src/contexts/FileSystemEventsContext.jsx
+++ b/src/contexts/FileSystemEventsContext.jsx
@@ -1,0 +1,129 @@
+import React, { createContext, useContext, useEffect, useCallback } from 'react';
+import { fileSystemEvents } from '../core/fs/FileSystemEvents';
+
+/**
+ * Context for file system events
+ * Provides access to the file system event emitter and utility functions
+ */
+const FileSystemEventsContext = createContext(null);
+
+/**
+ * Provider component for file system events
+ * Wraps children with access to file system event utilities
+ */
+export function FileSystemEventsProvider({ children }) {
+  const value = {
+    /**
+     * Emit a file deleted event
+     * @param {string} path - Path of deleted file/folder
+     */
+    emitFileDeleted: useCallback((path) => {
+      fileSystemEvents.emitFileDeleted(path);
+    }, []),
+
+    /**
+     * Emit a file renamed event
+     * @param {string} oldPath - Previous path
+     * @param {string} newPath - New path
+     */
+    emitFileRenamed: useCallback((oldPath, newPath) => {
+      fileSystemEvents.emitFileRenamed(oldPath, newPath);
+    }, []),
+
+    /**
+     * Emit a file moved event
+     * @param {string} oldPath - Previous path
+     * @param {string} newPath - New path
+     */
+    emitFileMoved: useCallback((oldPath, newPath) => {
+      fileSystemEvents.emitFileMoved(oldPath, newPath);
+    }, []),
+
+    /**
+     * Check if a path is affected by an operation
+     */
+    isPathAffected: fileSystemEvents.isPathAffected.bind(fileSystemEvents),
+
+    /**
+     * Get updated path after rename/move
+     */
+    getUpdatedPath: fileSystemEvents.getUpdatedPath.bind(fileSystemEvents),
+  };
+
+  return (
+    <FileSystemEventsContext.Provider value={value}>
+      {children}
+    </FileSystemEventsContext.Provider>
+  );
+}
+
+/**
+ * Hook to access file system event emitters
+ * @returns {Object} File system event emitters and utilities
+ */
+export function useFileSystemEvents() {
+  const context = useContext(FileSystemEventsContext);
+  if (!context) {
+    throw new Error('useFileSystemEvents must be used within a FileSystemEventsProvider');
+  }
+  return context;
+}
+
+/**
+ * Hook to subscribe to file deletion events
+ * @param {Function} callback - Called with { path } when a file is deleted
+ */
+export function useOnFileDeleted(callback) {
+  useEffect(() => {
+    const unsubscribe = fileSystemEvents.on('file:deleted', callback);
+    return unsubscribe;
+  }, [callback]);
+}
+
+/**
+ * Hook to subscribe to file rename events
+ * @param {Function} callback - Called with { oldPath, newPath } when a file is renamed
+ */
+export function useOnFileRenamed(callback) {
+  useEffect(() => {
+    const unsubscribe = fileSystemEvents.on('file:renamed', callback);
+    return unsubscribe;
+  }, [callback]);
+}
+
+/**
+ * Hook to subscribe to file move events
+ * @param {Function} callback - Called with { oldPath, newPath } when a file is moved
+ */
+export function useOnFileMoved(callback) {
+  useEffect(() => {
+    const unsubscribe = fileSystemEvents.on('file:moved', callback);
+    return unsubscribe;
+  }, [callback]);
+}
+
+/**
+ * Hook to subscribe to all file change events (delete, rename, move)
+ * @param {Object} callbacks - Object with onDeleted, onRenamed, onMoved callbacks
+ */
+export function useFileChangeEvents({ onDeleted, onRenamed, onMoved }) {
+  useEffect(() => {
+    const unsubscribes = [];
+
+    if (onDeleted) {
+      unsubscribes.push(fileSystemEvents.on('file:deleted', onDeleted));
+    }
+    if (onRenamed) {
+      unsubscribes.push(fileSystemEvents.on('file:renamed', onRenamed));
+    }
+    if (onMoved) {
+      unsubscribes.push(fileSystemEvents.on('file:moved', onMoved));
+    }
+
+    return () => {
+      unsubscribes.forEach(unsub => unsub());
+    };
+  }, [onDeleted, onRenamed, onMoved]);
+}
+
+export default FileSystemEventsContext;

--- a/src/core/fs/FileSystemEvents.js
+++ b/src/core/fs/FileSystemEvents.js
@@ -1,0 +1,73 @@
+import { EventEmitter } from '../../utils/EventEmitter';
+
+/**
+ * FileSystemEventEmitter - Centralized event system for file system changes
+ *
+ * Emits events when files are deleted, renamed, or moved so that
+ * connected components (tabs, breadcrumbs, etc.) can react accordingly.
+ *
+ * Events:
+ * - file:deleted { path: string } - When a file/folder is deleted
+ * - file:renamed { oldPath: string, newPath: string } - When a file/folder is renamed
+ * - file:moved { oldPath: string, newPath: string } - When a file/folder is moved
+ */
+class FileSystemEventEmitter extends EventEmitter {
+  /**
+   * Emit when a file or folder is deleted
+   * @param {string} path - The path of the deleted file/folder
+   */
+  emitFileDeleted(path) {
+    this.emit('file:deleted', { path });
+  }
+
+  /**
+   * Emit when a file or folder is renamed
+   * @param {string} oldPath - The previous path
+   * @param {string} newPath - The new path after rename
+   */
+  emitFileRenamed(oldPath, newPath) {
+    this.emit('file:renamed', { oldPath, newPath });
+  }
+
+  /**
+   * Emit when a file or folder is moved
+   * @param {string} oldPath - The previous path
+   * @param {string} newPath - The new path after move
+   */
+  emitFileMoved(oldPath, newPath) {
+    this.emit('file:moved', { oldPath, newPath });
+  }
+
+  /**
+   * Check if a path is affected by a file operation
+   * Used by consumers to determine if they need to update
+   * @param {string} targetPath - Path being checked
+   * @param {string} operationPath - Path where operation occurred
+   * @returns {boolean} - True if targetPath is the same as or inside operationPath
+   */
+  isPathAffected(targetPath, operationPath) {
+    return targetPath === operationPath || targetPath.startsWith(operationPath + '/');
+  }
+
+  /**
+   * Get updated path after a rename/move operation
+   * @param {string} targetPath - The path to update
+   * @param {string} oldPath - The old base path
+   * @param {string} newPath - The new base path
+   * @returns {string} - The updated path
+   */
+  getUpdatedPath(targetPath, oldPath, newPath) {
+    if (targetPath === oldPath) {
+      return newPath;
+    }
+    if (targetPath.startsWith(oldPath + '/')) {
+      return newPath + targetPath.slice(oldPath.length);
+    }
+    return targetPath;
+  }
+}
+
+// Singleton instance for global access
+export const fileSystemEvents = new FileSystemEventEmitter();
+
+export default FileSystemEventEmitter;


### PR DESCRIPTION
## Summary

- Created a file system event system that broadcasts when files are deleted, renamed, or moved
- Connected tabs, breadcrumbs, split view, and version history to react to these events in real-time
- When a file is deleted: tab closes automatically, active file switches to another tab
- When a file is renamed/moved: tab name updates, breadcrumbs update, paths update

## Changes

**New files:**
- `src/core/fs/FileSystemEvents.js` - Event emitter for file system changes
- `src/contexts/FileSystemEventsContext.jsx` - React context and hooks for subscribing to events

**Modified:**
- `src/views/Workspace.jsx` - Emit events on file operations, subscribe to update UI state

## Test plan

- [ ] Open multiple files as tabs
- [ ] Delete a file that has an open tab - verify tab closes automatically
- [ ] Rename a file that has an open tab - verify tab name and breadcrumbs update
- [ ] Move a file (drag to another folder) - verify tab path updates
- [ ] Test with split view open - verify right pane updates on delete/rename/move
- [ ] Test version history panel - verify it updates on delete/rename/move

🤖 Generated with [Claude Code](https://claude.com/claude-code)