### PR TITLE
Fix Cmd+S saving stale markdown content to kanban/canvas files

### DIFF
--- a/src/views/Workspace.jsx
+++ b/src/views/Workspace.jsx
@@ -1701,6 +1701,7 @@ function WorkspaceWithScope({ path }) {
       try { window.__LOKUS_ACTIVE_FILE__ = activeFile; } catch { }
 
       // Skip loading content for special views and binary files
+      // but clear editor state to prevent stale content from being used
       if (
         activeFile.startsWith('__') ||
         activeFile.endsWith('.canvas') ||
@@ -1708,6 +1709,8 @@ function WorkspaceWithScope({ path }) {
         activeFile.endsWith('.pdf') ||
         isImageFile(activeFile)
       ) {
+        setEditorContent("");
+        setEditorTitle("");
         return;
       }
 

--- a/src/views/Workspace.jsx
+++ b/src/views/Workspace.jsx
@@ -2380,6 +2380,9 @@ function WorkspaceWithScope({ path }) {
     const { activeFile, openTabs, editorContent, editorTitle } = stateRef.current;
     if (!activeFile) return;
 
+    // Only save markdown files - other file types (kanban, canvas, etc.) have their own save mechanisms
+    if (!activeFile.endsWith('.md')) return;
+
     let path_to_save = activeFile;
     let needsStateUpdate = false;
     const saveStartTime = performance.now();


### PR DESCRIPTION
## Summary

- Fixes bug where pressing Cmd+S while viewing a kanban board or canvas would corrupt the file by saving stale markdown content
- Adds guard in `handleSave()` to only save `.md` files - other file types have their own save mechanisms
- Clears `editorContent` and `editorTitle` state when switching to non-editable files to prevent stale data issues

## Problem

When a markdown file was open and then a kanban board was opened, the editor state (`editorContent`, `editorTitle`) was never cleared. Pressing Cmd+S would call `handleSave()` which would attempt to save the old markdown content to the kanban file, corrupting it.

## Solution

Two-layer fix:
1. **Root cause**: Clear editor state when switching to non-editable file types (kanban, canvas, pdf, images, special views)
2. **Defense in depth**: `handleSave()` now validates that the active file is a `.md` file before proceeding

## Test plan

- [ ] Open a markdown file and make edits
- [ ] Switch to a kanban board without saving the markdown
- [ ] Press Cmd+S while viewing the kanban board
- [ ] Verify the kanban board is not corrupted
- [ ] Switch back to the markdown file and verify it can still be saved normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)