### PR TITLE
Fixed the Cmd+K template insertion

### DIFF
--- a/src/components/CommandPalette.jsx
+++ b/src/components/CommandPalette.jsx
@@ -463,38 +463,34 @@ export default function CommandPalette({
   const handleTemplateSelect = React.useCallback(async (template) => {
 
     try {
-      // Process the template with built-in variables
       const result = await processTemplate(template.id, {}, {
         context: {}
       })
 
-      // Track template feature usage (rate limited to once per session)
+      // Track template feature usage
       analytics.trackFeatureUsed('templates')
 
-      // Call onShowTemplatePicker with processed content
-      if (onShowTemplatePicker) {
-        // Create a mock event that mimics the TemplatePicker selection
-        const mockSelection = {
+      // Dispatch event to insert template into editor
+      window.dispatchEvent(new CustomEvent('lokus:insert-template', {
+        detail: {
           template,
-          processedContent: result.result || result.content || result
+          content: result.result || result.content || result
         }
-        onShowTemplatePicker(mockSelection)
-      }
+      }))
 
       // Close command palette
       setOpen(false)
     } catch (err) {
       // Fallback to raw template content
-      if (onShowTemplatePicker) {
-        const mockSelection = {
+      window.dispatchEvent(new CustomEvent('lokus:insert-template', {
+        detail: {
           template,
-          processedContent: template.content
+          content: template.content
         }
-        onShowTemplatePicker(mockSelection)
-      }
+      }))
       setOpen(false)
     }
-  }, [processTemplate, onShowTemplatePicker, setOpen])
+  }, [processTemplate, setOpen])
 
   // Parse Gmail commands from input
   const [inputValue, setInputValue] = React.useState('')

--- a/src/editor/components/Editor.jsx
+++ b/src/editor/components/Editor.jsx
@@ -775,6 +775,14 @@ const Tiptap = forwardRef(({ extensions, content, onContentChange, editorSetting
       setMathFormulaModalState({ isOpen: true, mode, onInsert });
     };
 
+    // Listen for template insertion from Command Palette
+    const handleInsertTemplate = (event) => {
+      const { content } = event.detail;
+      if (editor && content) {
+        editor.chain().focus().insertContent(content).run();
+      }
+    };
+
     document.addEventListener('keydown', handleKeyDown);
     window.addEventListener('lokus:open-task-modal', handleTaskModalEvent);
     window.addEventListener('wiki-link-hover', handleWikiLinkHover);
@@ -782,6 +790,7 @@ const Tiptap = forwardRef(({ extensions, content, onContentChange, editorSetting
     window.addEventListener('open-image-insert-modal', handleImageInsertModalEvent);
     window.addEventListener('lokus:open-image-url-modal', handleImageUrlModalEvent);
     window.addEventListener('open-math-formula-modal', handleMathFormulaModalEvent);
+    window.addEventListener('lokus:insert-template', handleInsertTemplate);
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
@@ -791,6 +800,7 @@ const Tiptap = forwardRef(({ extensions, content, onContentChange, editorSetting
       window.removeEventListener('open-image-insert-modal', handleImageInsertModalEvent);
       window.removeEventListener('lokus:open-image-url-modal', handleImageUrlModalEvent);
       window.removeEventListener('open-math-formula-modal', handleMathFormulaModalEvent);
+      window.removeEventListener('lokus:insert-template', handleInsertTemplate);
     };
   }, [editor]);
 


### PR DESCRIPTION
## 📝 Description
When using the command palette (Cmd+K) to insert a template while a file is open in the editor, the template insertion fails. The only workaround is to use the / slash command instead. This gets fixed.

**What type of PR is this?**
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [x] 🔄 Refactor
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🎨 Style/UI
- [ ] ⚡ Performance
- [ ] 🔧 Tooling

**What does this PR do?**
Templates selected via Cmd+K should be inserted at the cursor position in the currently open file, just like they work via the / slash command.

**Related issue(s):**
#369 

## 🧪 Testing

**How was this tested?**
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [ ] Cross-platform testing (Windows/macOS/Linux)

## 📋 Checklist

**Before submitting this PR, please make sure:**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 📝 Additional Notes

<!-- Any additional information, context, or notes for reviewers -->

## 🏷️ Release Notes

<!-- How should this change appear in the release notes? -->
**User-facing changes:**
Try to insert template using cmd+k, the template will get inserted at the next line.

/cc @CodeWithInferno 