### PR TITLE
feat: implement multiple selection for file entries

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2073,3 +2073,13 @@ html, body {
     --text-base: 16px;
   }
 }
+
+.obsidian-file-item.selected {
+  background: rgba(var(--accent), 0.15) !important;
+  border-left: 1px solid rgb(var(--accent)) !important;
+  padding-left: calc(0.5rem - 2px) !important;
+}
+
+.obsidian-file-item.selected:hover {
+  background: rgba(var(--accent), 0.25) !important;
+}


### PR DESCRIPTION
## 📝 Description
The file explorer currently lacks standard bulk selection capabilities that users expect from file managers.

**What type of PR is this?**
- [x] ✨ New feature  
- [x] 🔄 Refactor
- [x] 🎨 Style/UI

**What does this PR do?**
<!-- Provide a clear and concise description of what this PR accomplishes -->

**Related issue(s):**
#364 File explorer: Add bulk selection (Cmd+click, Shift+click) 

## 🧪 Testing

**How was this tested?**
- [x] Manual testing performed
- [ ] Cross-platform testing (Windows/macOS/Linux)

## 📋 Checklist

**Before submitting this PR, please make sure:**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

/cc @CodeWithInferno 