### PR TITLE
fix: disable update checker for Mac App Store builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,7 @@ VITE_UMAMI_API_ENDPOINT=https://analytics.lokusmd.com
 
 # Note: Copy this file to .env and replace with your actual credentials
 # Never commit the actual .env file with real credentials to git
+
+# Set to 'true' for Mac App Store builds to disable in-app update checks
+# (Apple Guideline 2.4.5 requires App Store apps to only update via the store)
+VITE_DISABLE_UPDATE_CHECKER=false

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "bundle:mcp": "node scripts/bundle-mcp.cjs",
     "build:windows": "npm run bundle:mcp && node scripts/build-windows.js",
     "build:macos": "npm run bundle:mcp && node scripts/build-macos.js",
-    "build:appstore": "npm run bundle:mcp && npm run build && tauri build --config src-tauri/tauri.appstore.conf.json",
+    "build:appstore": "VITE_DISABLE_UPDATE_CHECKER=true npm run bundle:mcp && npm run build && tauri build --config src-tauri/tauri.appstore.conf.json",
     "build:linux": "npm run bundle:mcp && node scripts/build-linux.js",
     "build:all": "node scripts/check-platform.js && npm run build:all:cross",
     "build:all:cross": "npm run build:windows && npm run build:macos && npm run build:linux",

--- a/src/components/UpdateChecker.jsx
+++ b/src/components/UpdateChecker.jsx
@@ -6,6 +6,9 @@ import { showEnhancedToast } from './ui/enhanced-toast';
 import { readConfig } from '../core/config/store.js';
 import { getAppVersion } from '../utils/appInfo.js';
 
+// Disable update checks for Mac App Store builds (Apple Guideline 2.4.5)
+const UPDATES_DISABLED = import.meta.env.VITE_DISABLE_UPDATE_CHECKER === 'true';
+
 // Update endpoints
 const BETA_ENDPOINT = 'https://config.lokusmd.com/api/updates/beta.json';
 
@@ -94,6 +97,12 @@ export default function UpdateChecker() {
   const downloadToastId = useRef(null);
 
   const checkForUpdate = async () => {
+    // Skip update checks for App Store builds
+    if (UPDATES_DISABLED) {
+      console.debug('[UpdateChecker] Update checking disabled for this build');
+      return null;
+    }
+
     // Don't show again if already shown this session or dismissed
     if (hasShownUpdateThisSession || dismissed) {
       return null;


### PR DESCRIPTION
## Summary
- Adds `VITE_DISABLE_UPDATE_CHECKER` env var to skip update checks in App Store builds
- Updates `build:appstore` script to set the env var automatically
- Documents the env var in `.env.example`

## Problem
Apple rejected the app due to Guideline 2.4.5(vii) - apps must not check for updates outside the Mac App Store.

## Solution
The `UpdateChecker.jsx` component now checks for the `VITE_DISABLE_UPDATE_CHECKER` env var and returns early if set to `'true'`. The `build:appstore` script sets this automatically.

## Test plan
- [ ] Run `npm run build:appstore` and verify no update check API calls are made
- [ ] Run normal `npm run build:macos` and verify update checking still works