### PR TITLE
feat: Hide keyboard shortcut hints on mobile

### DIFF
--- a/src/components/CommandPalette.jsx
+++ b/src/components/CommandPalette.jsx
@@ -48,6 +48,7 @@ import posthog from '../services/posthog.js'
 import FolderSelector from './FolderSelector.jsx'
 import { useCommands, useCommandExecute } from '../hooks/useCommands.js'
 import { getMarkdownCompiler } from '../core/markdown/compiler.js'
+import { isDesktop } from '../platform/index.js';
 
 const markdownCompiler = getMarkdownCompiler()
 
@@ -1265,29 +1266,29 @@ Best regards,
             <CommandItem onSelect={() => runCommandWithHistory(onCreateFile, 'New File')}>
               <Plus className="mr-2 h-4 w-4" />
               <span>New File</span>
-              <CommandShortcut>{formatAccelerator(shortcuts['new-file'])}</CommandShortcut>
+              {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['new-file'])}</CommandShortcut>)}
             </CommandItem>
             <CommandItem onSelect={() => runCommandWithHistory(onCreateFolder, 'New Folder')}>
               <FolderPlus className="mr-2 h-4 w-4" />
               <span>New Folder</span>
-              <CommandShortcut>{formatAccelerator(shortcuts['new-folder'])}</CommandShortcut>
+              {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['new-folder'])}</CommandShortcut>)}
             </CommandItem>
             <CommandItem onSelect={() => runCommandWithHistory(onOpenDailyNote, 'Open Daily Note')}>
               <Calendar className="mr-2 h-4 w-4" />
               <span>Open Daily Note</span>
-              <CommandShortcut>{formatAccelerator(shortcuts['daily-note'])}</CommandShortcut>
+              {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['daily-note'])}</CommandShortcut>)}
             </CommandItem>
             {activeFile && (
               <>
                 <CommandItem onSelect={() => runCommandWithHistory(onSave, 'Save File', { fileName: activeFile.name })}>
                   <Save className="mr-2 h-4 w-4" />
                   <span>Save File</span>
-                  <CommandShortcut>{formatAccelerator(shortcuts['save-file'])}</CommandShortcut>
+                  {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['save-file'])}</CommandShortcut>)}
                 </CommandItem>
                 <CommandItem onSelect={() => runCommandWithHistory(() => onCloseTab(activeFile), 'Close Tab', { fileName: activeFile.name })}>
                   <X className="mr-2 h-4 w-4" />
                   <span>Close Tab</span>
-                  <CommandShortcut>{formatAccelerator(shortcuts['close-tab'])}</CommandShortcut>
+                  {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['close-tab'])}</CommandShortcut>)}
                 </CommandItem>
                 {/* Individual template commands */}
                 {templates.map((template) => (
@@ -1308,7 +1309,7 @@ Best regards,
                 >
                   <Plus className="mr-2 h-4 w-4" />
                   <span>Save as Template</span>
-                  <CommandShortcut>S</CommandShortcut>
+                  {isDesktop() && <CommandShortcut>S</CommandShortcut>}
                 </CommandItem>
               </>
             )}
@@ -1321,22 +1322,22 @@ Best regards,
             <CommandItem onSelect={() => runCommandWithHistory(onToggleSidebar, 'Toggle Sidebar')}>
               <ToggleLeft className="mr-2 h-4 w-4" />
               <span>Toggle Sidebar</span>
-              <CommandShortcut>{formatAccelerator(shortcuts['toggle-sidebar'])}</CommandShortcut>
+              {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['toggle-sidebar'])}</CommandShortcut>)}
             </CommandItem>
             <CommandItem onSelect={() => runCommandWithHistory(onOpenPreferences, 'Open Preferences')}>
               <Settings className="mr-2 h-4 w-4" />
               <span>Open Preferences</span>
-              <CommandShortcut>{formatAccelerator(shortcuts['open-preferences'])}</CommandShortcut>
+              {isDesktop() && (<CommandShortcut>{formatAccelerator(shortcuts['open-preferences'])}</CommandShortcut>)}
             </CommandItem>
             <CommandItem onSelect={() => runCommandWithHistory(onOpenGraph, 'Open Graph View')}>
               <Network className="mr-2 h-4 w-4" />
               <span>Professional Graph View</span>
-              <CommandShortcut>⌘G</CommandShortcut>
+              {isDesktop() && <CommandShortcut>⌘G</CommandShortcut>}
             </CommandItem>
             <CommandItem onSelect={() => runCommandWithHistory(onOpenGmail, 'Open Gmail')}>
               <Mail className="mr-2 h-4 w-4" />
               <span>Gmail</span>
-              <CommandShortcut>⌘M</CommandShortcut>
+              {isDesktop() && <CommandShortcut>⌘M</CommandShortcut>}
             </CommandItem>
           </CommandGroup>
 
@@ -1347,7 +1348,7 @@ Best regards,
             <CommandItem onSelect={() => runCommandWithHistory(handleOpenFolderSelector, 'Switch to Local View')}>
               <Target className="mr-2 h-4 w-4" />
               <span>Switch to Local View</span>
-              <CommandShortcut>⌘⇧L</CommandShortcut>
+              {isDesktop() && <CommandShortcut>⌘⇧L</CommandShortcut>}
             </CommandItem>
             {scopeMode === 'local' && (
               <CommandItem onSelect={() => runCommandWithHistory(() => {
@@ -1378,7 +1379,7 @@ Best regards,
             }, 'Create New Base')}>
               <Database className="mr-2 h-4 w-4" />
               <span>Create New Base</span>
-              <CommandShortcut>⌘⇧B</CommandShortcut>
+              {isDesktop() && <CommandShortcut>⌘⇧B</CommandShortcut>}
             </CommandItem>
             {bases && bases.length > 0 && bases.map((base) => (
               <CommandItem
@@ -1389,7 +1390,7 @@ Best regards,
               >
                 <Database className="mr-2 h-4 w-4" />
                 <span>Open {base.name}</span>
-                <CommandShortcut className="text-xs">{base.description || 'Base'}</CommandShortcut>
+                {isDesktop() && <CommandShortcut className="text-xs">{base.description || 'Base'}</CommandShortcut>}
               </CommandItem>
             ))}
           </CommandGroup>
@@ -1424,7 +1425,7 @@ Best regards,
                       <FileText className="mr-2 h-4 w-4" />
                     )}
                     <span>{cmd.title || cmd.id}</span>
-                    {cmd.category && (
+                    {isDesktop() && cmd.category && (
                       <CommandShortcut className="text-xs">{cmd.category}</CommandShortcut>
                     )}
                   </CommandItem>
@@ -1446,7 +1447,7 @@ Best regards,
               }, 'Authenticate Gmail')}>
                 <Mail className="mr-2 h-4 w-4" />
                 <span>Authenticate Gmail</span>
-                <CommandShortcut>Auth</CommandShortcut>
+                {isDesktop() && <CommandShortcut>Auth</CommandShortcut>}
               </CommandItem>
             ) : (
               <>
@@ -1469,7 +1470,7 @@ Best regards,
                 >
                   <Send className="mr-2 h-4 w-4" />
                   <span>Send Gmail</span>
-                  <CommandShortcut>Send</CommandShortcut>
+                  {isDesktop() && <CommandShortcut>Send</CommandShortcut>}
                 </CommandItem>
               </>
             )}

--- a/src/components/EditorContextMenu.jsx
+++ b/src/components/EditorContextMenu.jsx
@@ -46,6 +46,8 @@ import {
   SeparatorHorizontal
 } from 'lucide-react';
 import platformService from '../services/platform/PlatformService';
+import { isDesktop } from '../platform/index.js';
+
 
 export default function EditorContextMenu({
   children,
@@ -83,7 +85,7 @@ export default function EditorContextMenu({
         >
           <Scissors className="mr-2 h-4 w-4" />
           Cut
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem
@@ -92,13 +94,13 @@ export default function EditorContextMenu({
         >
           <Copy className="mr-2 h-4 w-4" />
           Copy
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem onClick={() => handleAction('paste')}>
           <Clipboard className="mr-2 h-4 w-4" />
           Paste
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+V' : '⌘V'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+V' : '⌘V'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -116,7 +118,7 @@ export default function EditorContextMenu({
             >
               <Bold className="mr-2 h-4 w-4" />
               Bold
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+B' : '⌘B'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+B' : '⌘B'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem
               onClick={() => handleAction('toggleItalic')}
@@ -124,7 +126,7 @@ export default function EditorContextMenu({
             >
               <Italic className="mr-2 h-4 w-4" />
               Italic
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+I' : '⌘I'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+I' : '⌘I'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem
               onClick={() => handleAction('toggleStrikethrough')}
@@ -132,7 +134,7 @@ export default function EditorContextMenu({
             >
               <Strikethrough className="mr-2 h-4 w-4" />
               Strikethrough
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+X' : '⌘⇧X'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+X' : '⌘⇧X'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem
               onClick={() => handleAction('toggleCode')}
@@ -140,13 +142,13 @@ export default function EditorContextMenu({
             >
               <Code className="mr-2 h-4 w-4" />
               Inline Code
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+E' : '⌘E'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+E' : '⌘E'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuSeparator />
             <ContextMenuItem onClick={() => handleAction('clearFormatting')}>
               <Type className="mr-2 h-4 w-4" />
               Clear Formatting
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+\\' : '⌘\\'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+\\' : '⌘\\'}</ContextMenuShortcut>)}
             </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
@@ -161,7 +163,7 @@ export default function EditorContextMenu({
             <ContextMenuItem onClick={() => handleAction('insertLink')}>
               <Link className="mr-2 h-4 w-4" />
               Link
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+K' : '⌘K'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+K' : '⌘K'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('insertImage')}>
               <Image className="mr-2 h-4 w-4" />
@@ -174,7 +176,7 @@ export default function EditorContextMenu({
             <ContextMenuItem onClick={() => handleAction('insertCodeBlock')}>
               <FileCode className="mr-2 h-4 w-4" />
               Code Block
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('insertQuote')}>
               <Quote className="mr-2 h-4 w-4" />
@@ -208,17 +210,17 @@ export default function EditorContextMenu({
             <ContextMenuItem onClick={() => handleAction('setHeading', { level: 1 })}>
               <Heading className="mr-2 h-4 w-4" />
               Heading 1
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+1' : '⌘⌥1'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+1' : '⌘⌥1'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('setHeading', { level: 2 })}>
               <Heading className="mr-2 h-4 w-4" />
               Heading 2
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+2' : '⌘⌥2'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+2' : '⌘⌥2'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('setHeading', { level: 3 })}>
               <Heading className="mr-2 h-4 w-4" />
               Heading 3
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+3' : '⌘⌥3'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+3' : '⌘⌥3'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('setHeading', { level: 4 })}>
               <Heading className="mr-2 h-4 w-4" />
@@ -236,7 +238,7 @@ export default function EditorContextMenu({
             <ContextMenuItem onClick={() => handleAction('setParagraph')}>
               <Type className="mr-2 h-4 w-4" />
               Normal Text
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+0' : '⌘⌥0'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Alt+0' : '⌘⌥0'}</ContextMenuShortcut>)}
             </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
@@ -251,17 +253,17 @@ export default function EditorContextMenu({
             <ContextMenuItem onClick={() => handleAction('toggleBulletList')}>
               <List className="mr-2 h-4 w-4" />
               Bullet List
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+8' : '⌘⇧8'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+8' : '⌘⇧8'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('toggleOrderedList')}>
               <ListOrdered className="mr-2 h-4 w-4" />
               Numbered List
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+7' : '⌘⇧7'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+7' : '⌘⇧7'}</ContextMenuShortcut>)}
             </ContextMenuItem>
             <ContextMenuItem onClick={() => handleAction('toggleTaskList')}>
               <CheckSquare className="mr-2 h-4 w-4" />
               Task List
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+9' : '⌘⇧9'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+9' : '⌘⇧9'}</ContextMenuShortcut>)}
             </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
@@ -272,7 +274,7 @@ export default function EditorContextMenu({
         <ContextMenuItem onClick={() => handleAction('selectAll')}>
           <MousePointer2 className="mr-2 h-4 w-4" />
           Select All
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+A' : '⌘A'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+A' : '⌘A'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -284,7 +286,7 @@ export default function EditorContextMenu({
         >
           <RotateCcw className="mr-2 h-4 w-4" />
           Undo
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+Z' : '⌘Z'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Z' : '⌘Z'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem
@@ -293,7 +295,7 @@ export default function EditorContextMenu({
         >
           <RotateCw className="mr-2 h-4 w-4" />
           Redo
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+Y' : '⌘⇧Z'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Y' : '⌘⇧Z'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -302,13 +304,13 @@ export default function EditorContextMenu({
         <ContextMenuItem onClick={() => handleAction('find')}>
           <Search className="mr-2 h-4 w-4" />
           Find
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+F' : '⌘F'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+F' : '⌘F'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem onClick={() => handleAction('findAndReplace')}>
           <SearchX className="mr-2 h-4 w-4" />
           Replace
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+H' : '⌘⌥F'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+H' : '⌘⌥F'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -317,7 +319,7 @@ export default function EditorContextMenu({
         <ContextMenuItem onClick={() => handleAction('commandPalette')}>
           <Zap className="mr-2 h-4 w-4" />
           Command Palette
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+P' : '⌘⇧P'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+P' : '⌘⇧P'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />

--- a/src/components/FileContextMenu.jsx
+++ b/src/components/FileContextMenu.jsx
@@ -112,7 +112,7 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('deleteSelected')}>
               <Trash2 className="mr-2 h-4 w-4 text-red-500" />
               <span className="text-red-500">Delete {selectedCount} Items</span>
-              <ContextMenuShortcut>{isWindows ? 'Del' : '⌫'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Del' : '⌫'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -120,13 +120,13 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('cutSelected')}>
               <Scissors className="mr-2 h-4 w-4" />
               Cut {selectedCount} Items
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuItem onClick={() => handleAction('copySelected')}>
               <Copy className="mr-2 h-4 w-4" />
               Copy {selectedCount} Items
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuItem onClick={() => handleAction('duplicateSelected')}>
@@ -164,13 +164,13 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('newFile')}>
               <FilePlus className="mr-2 h-4 w-4" />
               New File
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+N' : '⌘N'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+N' : '⌘N'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuItem onClick={() => handleAction('newFolder')}>
               <FolderPlus className="mr-2 h-4 w-4" />
               New Folder
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+N' : '⌘⇧N'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+N' : '⌘⇧N'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -183,7 +183,7 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('open')}>
               {getFileTypeIcon()}
               Open
-              <ContextMenuShortcut>Enter</ContextMenuShortcut>
+              {isDesktop() && <ContextMenuShortcut>Enter</ContextMenuShortcut>}
             </ContextMenuItem>
 
             {isFile && (
@@ -191,13 +191,13 @@ export default function FileContextMenu({
                 <ContextMenuItem onClick={() => handleAction('openToSide')}>
                   <ArrowRight className="mr-2 h-4 w-4" />
                   Open to the Side
-                  <ContextMenuShortcut>{isWindows ? 'Ctrl+Enter' : '⌘Enter'}</ContextMenuShortcut>
+                  {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Enter' : '⌘Enter'}</ContextMenuShortcut>)}
                 </ContextMenuItem>
 
                 <ContextMenuItem onClick={() => handleAction('viewHistory')}>
                   <Clock className="mr-2 h-4 w-4" />
                   View History
-                  <ContextMenuShortcut>{isWindows ? 'Ctrl+H' : '⌘H'}</ContextMenuShortcut>
+                  {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+H' : '⌘H'}</ContextMenuShortcut>)}
                 </ContextMenuItem>
 
                 <ContextMenuSub>
@@ -233,7 +233,7 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('revealInFinder')}>
               <FolderOpen className="mr-2 h-4 w-4" />
               {isMac ? 'Reveal in Finder' : isWindows ? 'Reveal in File Explorer' : 'Show in File Manager'}
-              <ContextMenuShortcut>{isWindows ? 'Alt+R' : '⌥R'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Alt+R' : '⌥R'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             {isDesktop() && (
@@ -256,7 +256,7 @@ export default function FileContextMenu({
             >
               <Scissors className="mr-2 h-4 w-4" />
               Cut
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+X' : '⌘X'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuItem
@@ -265,13 +265,13 @@ export default function FileContextMenu({
             >
               <Copy className="mr-2 h-4 w-4" />
               Copy
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+C' : '⌘C'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuItem onClick={() => handleAction('duplicate')}>
               <Files className="mr-2 h-4 w-4" />
               Duplicate
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+D' : '⌘D'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+D' : '⌘D'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -287,7 +287,7 @@ export default function FileContextMenu({
             >
               <Clipboard className="mr-2 h-4 w-4" />
               Paste
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+V' : '⌘V'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+V' : '⌘V'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -300,13 +300,13 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('rename')}>
               <Pencil className="mr-2 h-4 w-4" />
               Rename
-              <ContextMenuShortcut>F2</ContextMenuShortcut>
+              {isDesktop() && <ContextMenuShortcut>F2</ContextMenuShortcut>}
             </ContextMenuItem>
 
             <ContextMenuItem onClick={() => handleAction('delete')}>
               <Trash2 className="mr-2 h-4 w-4 text-red-500" />
               <span className="text-red-500">Delete</span>
-              <ContextMenuShortcut>{isWindows ? 'Del' : '⌘⌫'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Del' : '⌘⌫'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -325,12 +325,12 @@ export default function FileContextMenu({
                 <ContextMenuItem onClick={() => handleAction('copyPath')}>
                   <Link className="mr-2 h-4 w-4" />
                   Copy Path
-                  <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>
+                  {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>)}
                 </ContextMenuItem>
                 <ContextMenuItem onClick={() => handleAction('copyRelativePath')}>
                   <Link className="mr-2 h-4 w-4" />
                   Copy Relative Path
-                  <ContextMenuShortcut>{isWindows ? 'Ctrl+K Ctrl+Shift+C' : '⌘K ⌘⇧C'}</ContextMenuShortcut>
+                  {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+K Ctrl+Shift+C' : '⌘K ⌘⇧C'}</ContextMenuShortcut>)}
                 </ContextMenuItem>
               </ContextMenuSubContent>
             </ContextMenuSub>
@@ -345,7 +345,7 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('findInFolder')}>
               <Search className="mr-2 h-4 w-4" />
               Find in Folder...
-              <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+F' : '⌘⇧F'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+F' : '⌘⇧F'}</ContextMenuShortcut>)}
             </ContextMenuItem>
 
             <ContextMenuSeparator />
@@ -459,7 +459,7 @@ export default function FileContextMenu({
           <ContextMenuItem onClick={() => handleAction('refresh')}>
             <RefreshCw className="mr-2 h-4 w-4" />
             Refresh
-            <ContextMenuShortcut>F5</ContextMenuShortcut>
+            {isDesktop() && (<ContextMenuShortcut>F5</ContextMenuShortcut>)}
           </ContextMenuItem>
         )}
 
@@ -470,7 +470,7 @@ export default function FileContextMenu({
             <ContextMenuItem onClick={() => handleAction('properties')}>
               <FolderTree className="mr-2 h-4 w-4" />
               Properties
-              <ContextMenuShortcut>{isWindows ? 'Alt+Enter' : '⌘I'}</ContextMenuShortcut>
+              {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Alt+Enter' : '⌘I'}</ContextMenuShortcut>)}
             </ContextMenuItem>
           </>
         )}

--- a/src/components/ImageInsertModal.jsx
+++ b/src/components/ImageInsertModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Image as ImageIcon, Link as LinkIcon, Upload, X, ExternalLink } from 'lucide-react';
 import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+import { isDesktop } from '../platform/index.js';
 
 export default function ImageInsertModal({
   isOpen,
@@ -325,9 +326,11 @@ export default function ImageInsertModal({
 
         {/* Footer */}
         <div className="flex items-center justify-between p-4 border-t border-app-border bg-app-bg">
-          <div className="text-xs text-app-muted">
-            <span className="font-medium">⌘+Enter</span> to insert • <span className="font-medium">Esc</span> to cancel
-          </div>
+          {isDesktop() && (
+            <div className="text-xs text-app-muted">
+              <span className="font-medium">⌘+Enter</span> to insert • <span className="font-medium">Esc</span> to cancel
+            </div>
+          )}
           <div className="flex gap-2">
             <button
               onClick={onClose}

--- a/src/components/KanbanBoard.jsx
+++ b/src/components/KanbanBoard.jsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import MarkdownIt from "markdown-it";
 import { toast } from "sonner";
+import { isDesktop } from '../platform/index.js';
 
 // Initialize markdown renderer
 const md = new MarkdownIt({
@@ -222,7 +223,9 @@ function TaskCard({ task, onUpdate, onDelete, isDragging }) {
             autoFocus
           />
           <div className="text-[10px] text-app-muted mt-1">
-            Press Cmd/Ctrl+Enter to save, Escape to cancel
+            {isDesktop()
+              ? 'Press Cmd/Ctrl+Enter to save, Escape to cancel'
+              : 'Tap outside the box to save, or cancel'}
           </div>
         </div>
       ) : task.description ? (

--- a/src/components/KanbanContextMenu.jsx
+++ b/src/components/KanbanContextMenu.jsx
@@ -18,6 +18,7 @@ import {
   Download,
 } from 'lucide-react';
 import platformService from '../services/platform/PlatformService';
+import { isDesktop } from '../platform/index.js';
 
 export default function KanbanContextMenu({
   children,
@@ -43,7 +44,7 @@ export default function KanbanContextMenu({
         <ContextMenuItem onClick={() => handleAction('open')}>
           <Trello className="mr-2 h-4 w-4" />
           Open Board
-          <ContextMenuShortcut>Enter</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>Enter</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -60,13 +61,13 @@ export default function KanbanContextMenu({
         <ContextMenuItem onClick={() => handleAction('duplicate')}>
           <Files className="mr-2 h-4 w-4" />
           Duplicate
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+D' : '⌘D'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+D' : '⌘D'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem onClick={() => handleAction('copyPath')}>
           <Link className="mr-2 h-4 w-4" />
           Copy Path
-          <ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Ctrl+Shift+C' : '⌘⇧C'}</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuSeparator />
@@ -83,13 +84,13 @@ export default function KanbanContextMenu({
         <ContextMenuItem onClick={() => handleAction('rename')}>
           <Pencil className="mr-2 h-4 w-4" />
           Rename
-          <ContextMenuShortcut>F2</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>F2</ContextMenuShortcut>)}
         </ContextMenuItem>
 
         <ContextMenuItem onClick={() => handleAction('delete')}>
           <Trash2 className="mr-2 h-4 w-4 text-red-500" />
           <span className="text-red-500">Delete</span>
-          <ContextMenuShortcut>{isWindows ? 'Del' : '⌘⌫'}</ContextMenuShortcut>
+          {isDesktop() && (<ContextMenuShortcut>{isWindows ? 'Del' : '⌘⌫'}</ContextMenuShortcut>)}
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/MathFormulaModal.jsx
+++ b/src/components/MathFormulaModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Sigma, X, AlertCircle } from 'lucide-react';
 import katex from 'katex';
 import 'katex/dist/katex.min.css';
+import { isDesktop } from '../platform/index.js';
 
 export default function MathFormulaModal({
   isOpen,
@@ -206,9 +207,11 @@ export default function MathFormulaModal({
 
         {/* Footer */}
         <div className="flex items-center justify-between p-4 border-t border-app-border bg-app-bg">
-          <div className="text-xs text-app-muted">
-            <span className="font-medium">⌘+Enter</span> to insert • <span className="font-medium">Esc</span> to cancel
-          </div>
+          {isDesktop() && (
+            <div className="text-xs text-app-muted">
+              <span className="font-medium">⌘+Enter</span> to insert • <span className="font-medium">Esc</span> to cancel
+            </div>
+          )}
           <div className="flex gap-2">
             <button
               onClick={onClose}

--- a/src/components/SearchPanel.jsx
+++ b/src/components/SearchPanel.jsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { Search, X, ChevronDown, ChevronRight, Settings, Clock } from 'lucide-react'
 import { sanitizeSearchHighlight, isValidSearchQuery } from '../core/security/index.js'
 import { getFilename } from '../utils/pathUtils.js'
+import { isDesktop } from '../platform/index.js';
 
 // Utility function to highlight search matches in text (XSS-safe)
 const highlightText = (text, query, options) => {
@@ -390,7 +391,9 @@ export default function SearchPanel({ isOpen, onClose, onFileOpen, workspacePath
               <div className="p-8 text-center text-app-muted">
                 <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />
                 <p>Start typing to search across your files</p>
-                <p className="text-sm mt-1">Press Ctrl+Shift+F to open search</p>
+                {isDesktop() && (
+                  <p className="text-sm mt-1">Press Ctrl+Shift+F to open search</p>
+                )}
               </div>
             )}
           </div>

--- a/src/components/ShortcutHelpModal.jsx
+++ b/src/components/ShortcutHelpModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { X, Keyboard } from "lucide-react";
 import { formatAccelerator } from "../core/shortcuts/registry.js";
+import { isDesktop } from '../platform/index.js';
 
 export default function ShortcutHelpModal({ isOpen, onClose }) {
   const [isMac, setIsMac] = useState(false);
@@ -171,9 +172,9 @@ export default function ShortcutHelpModal({ isOpen, onClose }) {
               color: 'rgb(var(--text))'
             }}>Esc</kbd> to close
           </div>
-          <div className="text-sm" style={{ color: 'rgb(var(--muted))' }}>
+          {isDesktop() && (<div className="text-sm" style={{ color: 'rgb(var(--muted))' }}>
             {isMac ? '⌘' : 'Ctrl'} = Command/Control key
-          </div>
+          </div>)}
         </div>
       </div>
     </div>

--- a/src/views/Preferences.jsx
+++ b/src/views/Preferences.jsx
@@ -22,6 +22,7 @@ import { useAuth } from "../core/auth/AuthContext";
 import { User, LogIn, LogOut, Crown, Shield, Settings as SettingsIcon } from "lucide-react";
 import QuickImport from "../components/QuickImport.jsx";
 import { getAppVersion } from "../utils/appInfo.js";
+import { isDesktop } from '../platform/index.js';
 
 export default function Preferences() {
   const [themes, setThemes] = useState([]);
@@ -2637,14 +2638,15 @@ export default function Preferences() {
                       Open today's daily note on startup
                     </label>
                   </div>
-
-                  <div className="pt-4 border-t border-app-border">
-                    <p className="text-sm text-app-muted mb-2">Quick access:</p>
-                    <ul className="text-sm space-y-1 text-app-muted">
-                      <li>• Press <kbd className="px-2 py-0.5 bg-app-bg border border-app-border rounded text-xs">Cmd/Ctrl + Shift + D</kbd> to open today's note</li>
-                      <li>• Use Command Palette (Cmd/Ctrl + K) → "Open Daily Note"</li>
-                    </ul>
-                  </div>
+                  {isDesktop() && ( 
+                    <div className="pt-4 border-t border-app-border">
+                      <p className="text-sm text-app-muted mb-2">Quick access:</p>
+                      <ul className="text-sm space-y-1 text-app-muted">
+                        <li>• Press <kbd className="px-2 py-0.5 bg-app-bg border border-app-border rounded text-xs">Cmd/Ctrl + Shift + D</kbd> to open today's note</li>
+                        <li>• Use Command Palette (Cmd/Ctrl + K) → "Open Daily Note"</li>
+                      </ul>
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/src/views/QuickSwitcher.jsx
+++ b/src/views/QuickSwitcher.jsx
@@ -11,6 +11,7 @@ import {
   highlightMatches,
 } from '../core/search/fuzzy-matcher.js';
 import '../styles/quick-switcher.css';
+import { isDesktop } from '../platform/index.js';
 
 /**
  * Enhanced Quick Switcher Component
@@ -418,12 +419,14 @@ export default function QuickSwitcher({ isOpen, onClose, onSelectFile, workspace
         </div>
 
         <div className="quick-switcher-footer">
-          <div className="footer-hint">
-            <kbd>↑↓</kbd> Navigate
-            <kbd>Enter</kbd> Open
-            <kbd>⌘Enter</kbd> Split
-            <kbd>Tab</kbd> Preview
-          </div>
+          {isDesktop() && (
+            <div className="footer-hint">
+              <kbd>↑↓</kbd> Navigate
+              <kbd>Enter</kbd> Open
+              <kbd>{isWindows ? 'Ctrl+Enter' : '⌘Enter'}</kbd> Split
+              <kbd>Tab</kbd> Preview
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/views/Workspace.jsx
+++ b/src/views/Workspace.jsx
@@ -4877,7 +4877,7 @@ function WorkspaceWithScope({ path }) {
                   </div>
                   <div className="text-sm text-app-muted">
                     <p className="mb-2">The graph view shows the connections between your notes.</p>
-                    <p>Use <kbd className="px-1 py-0.5 text-xs bg-app-panel rounded">Cmd+Shift+G</kbd> to quickly open the graph view.</p>
+                    {isDesktop() && (<p>Use <kbd className="px-1 py-0.5 text-xs bg-app-panel rounded">Cmd+Shift+G</kbd> to quickly open the graph view.</p>)}
                   </div>
                 </div>
               ) : (
@@ -4940,7 +4940,7 @@ function WorkspaceWithScope({ path }) {
                     <ContextMenuContent>
                       <ContextMenuItem onClick={handleCreateFile}>
                         New File
-                        <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['new-file'])}</span>
+                       { isDesktop() && <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['new-file'])}</span>} 
                       </ContextMenuItem>
                       {featureFlags.enable_canvas && (
                         <ContextMenuItem onClick={handleCreateCanvas}>
@@ -4949,11 +4949,11 @@ function WorkspaceWithScope({ path }) {
                       )}
                       <ContextMenuItem onClick={handleCreateFolder}>
                         New Folder
-                        <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['new-folder'])}</span>
+                        { isDesktop() && <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['new-folder'])}</span>}
                       </ContextMenuItem>
                       <ContextMenuItem onClick={handleOpenDailyNote}>
                         Open Daily Note
-                        <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['daily-note'])}</span>
+                        { isDesktop() && <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['daily-note'])}</span>}
                       </ContextMenuItem>
                       <ContextMenuSeparator />
                       <ContextMenuItem onClick={handleRefreshFiles}>Refresh</ContextMenuItem>
@@ -5306,11 +5306,11 @@ function WorkspaceWithScope({ path }) {
                                 <ContextMenuContent>
                                   <ContextMenuItem onClick={handleSave}>
                                     Save
-                                    <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['save-file'])}</span>
+                                    { isDesktop() && <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['save-file'])}</span>}
                                   </ContextMenuItem>
                                   <ContextMenuItem onClick={() => stateRef.current.activeFile && handleTabClose(stateRef.current.activeFile)}>
                                     Close Tab
-                                    <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['close-tab'])}</span>
+                                    { isDesktop() && <span className="ml-auto text-xs text-app-muted">{formatAccelerator(keymap['close-tab'])}</span>}
                                   </ContextMenuItem>
                                   <ContextMenuSeparator />
                                   <ContextMenuItem onClick={() => document.execCommand && document.execCommand('selectAll')}>Select All</ContextMenuItem>
@@ -5348,7 +5348,7 @@ function WorkspaceWithScope({ path }) {
                                   </div>
                                   <h3 className="font-medium text-app-text mb-2">New Note</h3>
                                   <p className="text-sm text-app-muted">Create your first note and start writing</p>
-                                  <div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+N")}</div>
+                                  {isDesktop() && (<div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+N")}</div>)}
                                 </button>
 
                                 {featureFlags.enable_canvas && (
@@ -5373,7 +5373,7 @@ function WorkspaceWithScope({ path }) {
                                   </div>
                                   <h3 className="font-medium text-app-text mb-2">New Folder</h3>
                                   <p className="text-sm text-app-muted">Organize your notes with folders</p>
-                                  <div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+Shift+N")}</div>
+                                  {isDesktop() && (<div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+Shift+N")}</div>)}
                                 </button>
 
                                 <button
@@ -5386,7 +5386,7 @@ function WorkspaceWithScope({ path }) {
                                   </div>
                                   <h3 className="font-medium text-app-text mb-2">Command Palette</h3>
                                   <p className="text-sm text-app-muted">Quick access to all commands</p>
-                                  <div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+K")}</div>
+                                  {isDesktop() && (<div className="mt-3 text-xs text-app-muted/70">{formatAccelerator("CommandOrControl+K")}</div>)}
                                 </button>
                               </div>
                             </div>
@@ -5447,7 +5447,7 @@ function WorkspaceWithScope({ path }) {
                                       <li>• Plugin system for extensibility</li>
                                     </ul>
                                   </div>
-
+                                  {isDesktop() && (
                                   <div className="p-4 rounded-lg bg-app-panel/20 border border-app-border/50">
                                     <h3 className="font-medium text-app-text text-sm mb-2">⌨️ Quick Tips</h3>
                                     <ul className="text-sm text-app-muted space-y-1">
@@ -5456,7 +5456,7 @@ function WorkspaceWithScope({ path }) {
                                       <li>• <kbd className="px-1.5 py-0.5 bg-app-bg/50 rounded text-xs">{platformService.getModifierSymbol()}+P</kbd> Quick file open</li>
                                       <li>• Drag files to move them between folders</li>
                                     </ul>
-                                  </div>
+                                  </div>)}
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
**What type of PR is this?**

 🐛 Bug fix
 🎨 Style UI improvement

**What does this PR do?**

Hides keyboard shortcut hints (like ⌘S or Ctrl+Z) on mobile devices.

Desktop still shows all keyboard shortcuts as before.

Prevents UI inconsistencies on mobile by wrapping shortcuts in isDesktop() checks.

**Related issue(s):**

Closes #319 (Hide keyboard shortcut hints (⌘S, Ctrl+Z) on mobile)

**🧪 Testing**

How was this tested?

 Manual testing performed on desktop and mobile simulation

**Test scenarios covered:**

On desktop, shortcuts (⌘S, Ctrl+Enter, etc.) are visible.

On mobile, shortcuts are hidden or replaced with touch-friendly hints.

No layout/UI breaks occur when shortcuts are hidden.

**🔄 Breaking Changes**

 No breaking changes


**📝 Additional Notes**

- All `<kbd>` elements showing keyboard shortcuts are now wrapped in `isDesktop()` checks to hide them on mobile.
- Accelerator spans inside context menu items (e.g., `{formatAccelerator(keymap['save-file'])}`) are also wrapped in `isDesktop()`.

**🏷️ Release Notes**

User-facing changes:

Keyboard shortcut hints no longer appear on mobile devices.

**Developer-facing changes:**

When adding new shortcuts in the future, wrap in isDesktop() to maintain mobile compatibility.