### PR TITLE
feat(calendar): Auto-link meeting attendees to people pages

### DIFF
--- a/src/core/attendees/attendee-linker.js
+++ b/src/core/attendees/attendee-linker.js
@@ -1,0 +1,106 @@
+/**
+ * Attendee Linker - Convert attendee names/emails to wiki-links
+ * 
+ * Matches attendees against existing pages in the workspace:
+ * 1. Exact match: "John Smith" → [[John Smith]]
+ * 2. Email prefix: "john.smith@company.com" → [[John Smith]]
+ * 3. Partial match: "John" → [[John Smith]] (if only one match)
+ */
+
+/** Get file index from global scope */
+function getFileIndex() {
+  const index = globalThis.__LOKUS_FILE_INDEX__ || [];
+  return Array.isArray(index) ? index : [];
+}
+
+/** Normalize string for comparison */
+function normalize(str) {
+  return (str || '').toLowerCase().trim().replace(/\s+/g, ' ').replace(/\.md$/i, '');
+}
+
+/** Extract name from email: john.smith@company.com → John Smith */
+function nameFromEmail(email) {
+  if (!email?.includes('@')) return null;
+  const local = email.split('@')[0];
+  return local?.replace(/[._-]/g, ' ')
+    .split(' ')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ')
+    .trim() || null;
+}
+
+/** Check if string is email format */
+function isEmail(str) {
+  return str && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(str.trim());
+}
+
+/** Get display title from file (without .md) */
+function getTitle(file) {
+  const title = file.title || file.path?.split('/').pop() || '';
+  return title.replace(/\.md$/i, '');
+}
+
+/** Find matching file for a name */
+function findMatch(name, files) {
+  const normalized = normalize(name);
+  if (!normalized) return null;
+  
+  // Exact match
+  const exact = files.find(f => normalize(getTitle(f)) === normalized);
+  if (exact) return exact;
+  
+  // Partial match (only if exactly one result)
+  const partial = files.filter(f => {
+    const title = normalize(getTitle(f));
+    return title.startsWith(normalized) || title.includes(` ${normalized}`);
+  });
+  return partial.length === 1 ? partial[0] : null;
+}
+
+/** Match single attendee to wiki page */
+function matchAttendee(attendee, files) {
+  const name = (attendee || '').trim();
+  if (!name) return name;
+  
+  // Try direct match
+  let match = findMatch(name, files);
+  if (match) return `[[${getTitle(match)}]]`;
+  
+  // Try email extraction
+  if (isEmail(name)) {
+    const extracted = nameFromEmail(name);
+    if (extracted) {
+      match = findMatch(extracted, files);
+      if (match) return `[[${getTitle(match)}]]`;
+    }
+  }
+  
+  return name; // No match - return as plain text
+}
+
+/**
+ * Convert attendees string to wiki-linked string
+ * @param {string|Array} attendees - Comma-separated string or array
+ * @returns {string} Attendees with wiki-links where matches exist
+ * 
+ * @example
+ * linkAttendees("John Smith, jane@company.com, Unknown")
+ * // → "[[John Smith]], [[Jane Doe]], Unknown"
+ */
+export function linkAttendees(attendees) {
+  if (!attendees) return '';
+  
+  const files = getFileIndex();
+  
+  // Parse input to array
+  const list = Array.isArray(attendees)
+    ? attendees.map(a => typeof a === 'string' ? a : a.displayName || a.name || a.email || '')
+    : String(attendees).split(',');
+  
+  // Match each attendee and join
+  return list
+    .map(a => a.trim())
+    .filter(a => a.length > 0)
+    .map(a => matchAttendee(a, files))
+    .join(', ');
+}

--- a/src/core/templates/filters.js
+++ b/src/core/templates/filters.js
@@ -6,6 +6,7 @@
  */
 
 import { format, formatDistance, formatRelative, parseISO } from 'date-fns';
+import { linkAttendees } from '../attendees/attendee-linker.js';
 
 /**
  * String Filters
@@ -737,7 +738,16 @@ export const allFilters = {
   ...numberFilters,
   ...dateFilters,
   ...objectFilters,
-  ...utilityFilters
+  ...utilityFilters,
+  // Attendee filter - converts names/emails to wiki-links
+  linkAttendees: (value) => {
+    if (!value) return '';
+    try {
+      return linkAttendees(value);
+    } catch {
+      return Array.isArray(value) ? value.join(', ') : String(value);
+    }
+  }
 };
 
 /**

--- a/src/editor/extensions/WikiLink.js
+++ b/src/editor/extensions/WikiLink.js
@@ -79,7 +79,19 @@ export const WikiLink = Node.create({
       src: { default: '' },
     }
   },
-  parseHTML() { return [{ tag: 'span[data-type="wiki-link"]' }] },
+  parseHTML() {
+    return [{
+      tag: 'span[data-type="wiki-link"]',
+      getAttrs: (el) => ({
+        href: el.getAttribute('href') || '',
+        target: el.getAttribute('target') || el.textContent || '',
+        alt: el.textContent || '',
+        embed: false,
+        src: '',
+        id: el.getAttribute('data-id') || '',
+      }),
+    }];
+  },
   renderHTML({ HTMLAttributes }) {
     const { embed, alt, target, href, src } = HTMLAttributes
     if (embed && src) {

--- a/src/hooks/useTemplates.js
+++ b/src/hooks/useTemplates.js
@@ -224,7 +224,7 @@ export function useTemplates() {
 
 **Date:** {{date}}
 **Time:** {{time}}
-**Attendees:** {{attendees || "Add attendees here"}}
+**Attendees:** {{attendees | linkAttendees || "Add attendees here"}}
 
 ## Agenda
 {{agenda || "Add agenda items here"}}


### PR DESCRIPTION
### What this PR does
- Automatically converts meeting attendees into wiki-links when matching people pages exist
- Supports exact name, email prefix, and partial matching
- Ensures backlinks appear on people pages for meetings attended

### Related issue
Closes #398