### PR TITLE
fix(mobile): make plugin panel width responsive (#320)

### DIFF
--- a/src/components/PluginPanel.jsx
+++ b/src/components/PluginPanel.jsx
@@ -12,6 +12,7 @@ import {
   Pin,
   PinOff
 } from "lucide-react";
+import { isMobile } from '../platform/index.js';
 
 // Plugin Panel Container for dynamic plugin UI components
 export default function PluginPanel({
@@ -227,7 +228,7 @@ export default function PluginPanel({
       ref={panelRef}
       className={`${positionClasses[position]} bg-app-panel text-app-text z-40 flex flex-col ${className}`}
       style={{
-        width: position !== "bottom" ? dimensions.width : undefined,
+        width: position !== "bottom" ? (isMobile() ? '100%' : dimensions.width) : undefined,
         height: position === "bottom" ? dimensions.height : undefined,
         transform: collapsed ? (
           position === "right" ? `translateX(${dimensions.width - 40}px)` :


### PR DESCRIPTION
## **Summary:**
Makes the plugin panel width responsive on mobile by using 100% width instead of a fixed 280px, preventing layout overflow on small screens.

## **Related issue:**
Closes #320