### PR TITLE
fix(mobile): make tab close button always visible on touch devices

### DIFF
--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { ColoredFileIcon } from './FileIcon.jsx';
+import React from "react";
+import { ColoredFileIcon } from "./FileIcon.jsx";
+
+import { isMobile } from "../platform/index.js";
 
 /**
  * TabBar - Simplified tab bar for editor groups
@@ -16,14 +18,16 @@ export default function TabBar({
   groupId,
 }) {
   const handleTabDragStart = (e, tab) => {
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('application/json', JSON.stringify(tab));
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("application/json", JSON.stringify(tab));
     onDragStart && onDragStart(tab);
   };
 
   const handleTabDragEnd = (e) => {
     onDragEnd && onDragEnd();
   };
+
+  const mobile = isMobile();
 
   if (!tabs || tabs.length === 0) {
     return (
@@ -38,7 +42,7 @@ export default function TabBar({
   return (
     <div className="h-12 shrink-0 flex items-end bg-app-panel border-b border-app-border px-0">
       <div className="flex-1 flex items-center overflow-x-auto no-scrollbar">
-        {tabs.map(tab => (
+        {tabs.map((tab) => (
           <div
             key={tab.path}
             draggable={true}
@@ -48,9 +52,10 @@ export default function TabBar({
             className={`
               group relative h-9 px-4 flex items-center gap-2 cursor-pointer
               transition-all duration-150 border-r border-app-border
-              ${activeTab === tab.path
-                ? 'bg-app-bg text-app-text border-b-2 border-b-app-accent'
-                : 'bg-app-panel text-app-muted hover:bg-app-bg/50 hover:text-app-text'
+              ${
+                activeTab === tab.path
+                  ? "bg-app-bg text-app-text border-b-2 border-b-app-accent"
+                  : "bg-app-panel text-app-muted hover:bg-app-bg/50 hover:text-app-text"
               }
             `}
           >
@@ -60,13 +65,14 @@ export default function TabBar({
               className="w-4 h-4 flex-shrink-0"
               showChevron={false}
             />
-            <span className="text-sm truncate max-w-[150px]">
-              {tab.name}
-            </span>
+            <span className="text-sm truncate max-w-[150px]">{tab.name}</span>
 
             {/* Unsaved indicator */}
             {unsavedChanges && unsavedChanges.has(tab.path) && (
-              <span className="w-2 h-2 rounded-full bg-app-accent" title="Unsaved changes" />
+              <span
+                className="w-2 h-2 rounded-full bg-app-accent"
+                title="Unsaved changes"
+              />
             )}
 
             {/* Close button */}
@@ -75,11 +81,29 @@ export default function TabBar({
                 e.stopPropagation();
                 onTabClose(tab.path);
               }}
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:bg-app-border rounded"
+              className={`
+                ${
+                  mobile
+                    ? "opacity-100 min-w-[44px] min-h-[44px] flex items-center justify-center"
+                    : "opacity-0 group-hover:opacity-100"
+                }
+                transition-opacity hover:bg-app-border rounded
+              `}
               title="Close"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-3 h-3">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                className="w-3 h-3"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
               </svg>
             </button>
           </div>


### PR DESCRIPTION
Implements fix for #313 

## Problem
Tab close buttons were hidden using `opacity-0 group-hover:opacity-100`.  
This works on desktop (hover interaction), but on touch devices, there is no hover state.  
As a result, mobile users could not see or tap the close button.

## Solution
- Wrapped mobile behavior inside `isMobile()` check.
- Made close button always visible on mobile.
- Kept hover-to-reveal behavior on desktop.
- Increased touch target to at least 44px for better tap accessibility.

### Implementation
```js
const mobile = isMobile();

className={`
  ${mobile
    ? 'opacity-100 min-w-[44px] min-h-[44px] flex items-center justify-center'
    : 'opacity-0 group-hover:opacity-100'}
  transition-opacity hover:bg-app-border rounded
`}