### PR TITLE
Issue #418 - fix: keep wiki link autocomplete open while typing

### DIFF
--- a/src/editor/lib/WikiLinkSuggest.js
+++ b/src/editor/lib/WikiLinkSuggest.js
@@ -212,11 +212,14 @@ const WikiLinkSuggest = Extension.create({
 
           // Use textBetween with absolute positions to properly handle inline nodes like WikiLinks
           // (parentOffset doesn't align with textContent when WikiLinks are present)
-          const textBefore = state.doc.textBetween(Math.max(parentStart, pos - 2), pos)
           const fullTextBefore = state.doc.textBetween(parentStart, pos)
 
           // Check for [[ pattern (file linking)
-          const isAfterDoubleBracket = textBefore.endsWith('[[')
+          // We need to check if we're INSIDE an unclosed [[ context, not just immediately after [[
+          // Look for [[ that doesn't have a matching ]]
+          const lastOpenBracket = fullTextBefore.lastIndexOf('[[')
+          const lastCloseBracket = fullTextBefore.lastIndexOf(']]')
+          const isInsideWikiLink = lastOpenBracket !== -1 && lastOpenBracket > lastCloseBracket
 
           // Check for ^ pattern within [[ ]] (block linking)
           // Look for pattern: [[Filename^ or [[Filename.md^
@@ -238,7 +241,7 @@ const WikiLinkSuggest = Extension.create({
           const isInList = isInListItem || isInTaskItem || isInNestedList
 
           // Note: ![ for canvas is handled by Plugin 2
-          const shouldAllow = (isAfterDoubleBracket || isAfterCaret) && !isInList
+          const shouldAllow = (isInsideWikiLink || isAfterCaret) && !isInList
           return shouldAllow
         },
         items: async ({ query, editor }) => {


### PR DESCRIPTION
Fixes #418

## 📝 Description

**What type of PR is this?**
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 🔄 Refactor
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🎨 Style/UI
- [ ] ⚡ Performance
- [ ] 🔧 Tooling

**What does this PR do?**
  Fixes the wiki link autocomplete menu disappearing immediately when typing after `[[`.

  The root cause was in the `allow()` function in `WikiLinkSuggest.js` - it only checked the 2 characters immediately before the cursor. When typing `[[a`, the check `textBefore.endsWith('[[')` failed because `textBefore` was `[a`, not `[[`.

  The fix changes the logic to check if the cursor is inside an unclosed `[[` context by comparing the positions of the last `[[` and `]]` in the text before the cursor.
  
  
**Related issue(s):**
Fixes #418 

## 🧪 Testing

**How was this tested?**
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [ ] Cross-platform testing (Windows/macOS/Linux)

**Test scenarios covered:**
1. Type `[[` - autocomplete menu appears with file suggestions
2. Type characters (e.g., `[[test`) - menu stays open and filters results
3. Continue typing longer queries - menu continues to filter correctly
4. Press Escape - menu closes
5. Select a file from suggestions - wiki link is inserted correctly

## 📸 Screenshots/Videos

<!-- For UI changes, please include before/after screenshots or a short video -->

## 📋 Checklist

**Before submitting this PR, please make sure:**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**For bug fixes:**
- [ ] I have added tests that would have caught this bug
- [x] I have verified the fix works in different scenarios
- [x] I have considered edge cases

## 🔄 Breaking Changes

<!-- If this PR contains breaking changes, describe them here -->
- [ ] This PR contains breaking changes
- [x] This PR is backwards compatible

## 📝 Additional Notes

The fix is minimal and localized to the `allow()` function in `src/editor/lib/WikiLinkSuggest.js`.
 

/cc @maintainers