### PR TITLE
fix: auto-create file when clikcing link to non-existent wikilink

### DIFF
--- a/src/editor/components/Editor.jsx
+++ b/src/editor/components/Editor.jsx
@@ -668,6 +668,10 @@ const Tiptap = forwardRef(({ extensions, content, onContentChange, editorSetting
               if (rootFile) {
                 cleanHref = rootFile.path;
                 fileExists = true;
+              } else {
+                // File doesn't exist - construct path in workspace root
+                const fileName = searchTerm.endsWith('.md') ? searchTerm : `${searchTerm}.md`;
+                cleanHref = wsPath ? `${wsPath}/${fileName}` : fileName;
               }
             } else {
               const hasPath = /[/\\]/.test(searchTerm);
@@ -691,8 +695,36 @@ const Tiptap = forwardRef(({ extensions, content, onContentChange, editorSetting
                 const sameFolder = candidates.find(f => dirname(f.path) === activeDir);
                 cleanHref = sameFolder ? sameFolder.path : candidates[0].path;
                 fileExists = true;
+              } else {
+                // File doesn't exist - construct absolute path for new file
+                // Create in same folder as current file
+                const wsPath = globalThis.__LOKUS_WORKSPACE_PATH__ || '';
+                const basePath = activeDir || wsPath;
+                const fileName = searchTerm.endsWith('.md') ? searchTerm : `${searchTerm}.md`;
+                cleanHref = basePath ? `${basePath}/${fileName}` : fileName;
               }
             }
+          }
+
+          // If cleanHref is still not an absolute path, construct one
+          // This handles cases where the index is empty or initial href was not found
+          const isAbsolutePath = cleanHref.startsWith('/') || /^[A-Za-z]:/.test(cleanHref);
+          if (!isAbsolutePath && !fileExists) {
+            const wsPath = globalThis.__LOKUS_WORKSPACE_PATH__ || '';
+            const activePath = globalThis.__LOKUS_ACTIVE_FILE__ || '';
+            const dirname = (p) => {
+              if (!p) return '';
+              const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+              return i >= 0 ? p.slice(0, i) : '';
+            };
+            const activeDir = dirname(activePath);
+            const basePath = activeDir || wsPath;
+            // Extract just the filename from cleanHref (remove any path components)
+            let fileName = cleanHref.split(/[\\/]/).pop() || cleanHref;
+            if (!fileName.endsWith('.md')) {
+              fileName = `${fileName}.md`;
+            }
+            cleanHref = basePath ? `${basePath}/${fileName}` : fileName;
           }
 
           // Emit to workspace to open file (Tauri or DOM event)

--- a/src/views/Workspace.jsx
+++ b/src/views/Workspace.jsx
@@ -2120,13 +2120,46 @@ function WorkspaceWithScope({ path }) {
           setSavedContent(content); // Keep original content for saving
           setIsLoadingContent(false); // Loading complete
         })
-        .catch((err) => {
-          if (fileToLoad === activeFile) {
-            setIsLoadingContent(false);
-            // Show error message in editor
-            setEditorContent(`<div class="text-red-500 p-4">Failed to load file: ${err}</div>`);
-            setEditorTitle("Error");
+        .catch(async (err) => {
+          if (fileToLoad !== activeFile) {
+            return;
           }
+
+          // Check if the error is "file not found" - auto-create the file
+          const errStr = String(err).toLowerCase();
+          const isFileNotFound = errStr.includes('no such file') ||
+                                 errStr.includes('not found') ||
+                                 errStr.includes('os error 2');
+
+          if (isFileNotFound && fileToLoad.endsWith('.md')) {
+            try {
+              // Auto-create the file with empty content
+              await invoke("write_file_content", { path: fileToLoad, content: "" });
+
+              // Set empty content for the new file
+              const fileName = getFilename(fileToLoad);
+              setEditorContent("");
+              setEditorTitle(fileName.replace(/\.md$/, ""));
+              setSavedContent("");
+              setIsLoadingContent(false);
+
+              // Refresh file index to include the new file
+              try {
+                const { emit } = await import('@tauri-apps/api/event');
+                await emit('lokus:refresh-file-index');
+              } catch {}
+
+              return;
+            } catch (createErr) {
+              // If creation also fails, show the original error
+              console.error('[Workspace] Failed to create file:', createErr);
+            }
+          }
+
+          setIsLoadingContent(false);
+          // Show error message in editor
+          setEditorContent(`<div class="text-red-500 p-4">Failed to load file: ${err}</div>`);
+          setEditorTitle("Error");
         });
     } else {
       setEditorContent("");


### PR DESCRIPTION
Fixes #419

## 📝 Description

**What type of PR is this?**
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 🔄 Refactor
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🎨 Style/UI
- [ ] ⚡ Performance
- [ ] 🔧 Tooling

**What does this PR do?**
Fixes the error shown when clicking a wiki link to a non-existent note. According to the documentation, "If the note doesn't exist yet, Lokus will create it when you click the link." However, clicking such links showed an error: `Failed to load file: No such file or directory (os error 2)`.

This PR fixes two issues:
1. **Editor.jsx**: Construct proper absolute file path for non-existent files (in the same folder as the current note or workspace root)
2. **Workspace.jsx**: Auto-create the markdown file when a "No such file" error occurs

**Related issue(s):**
Fixes #419 

## 🧪 Testing

**How was this tested?**
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [ ] Cross-platform testing (Windows/macOS/Linux)

**Test scenarios covered:**
1. Create wiki link to non-existent note: `[[NewNote]]`
2. Click the link - new file is created and opened (no error)
3. Create wiki link with explicit root path: `[[./RootNote]]` - file created in workspace root
4. Create wiki link in subfolder - file created in same folder as current note
5. Verify file content is empty and editable
  
## 📸 Screenshots/Videos

<!-- For UI changes, please include before/after screenshots or a short video -->

## 📋 Checklist

**Before submitting this PR, please make sure:**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**For bug fixes:**
- [ ] I have added tests that would have caught this bug
- [x] I have verified the fix works in different scenarios
- [x] I have considered edge cases

## 🔄 Breaking Changes

<!-- If this PR contains breaking changes, describe them here -->
- [ ] This PR contains breaking changes
- [x] This PR is backwards compatible

## 📝 Additional Notes

Changes are in two files:
- `src/editor/components/Editor.jsx`: Path construction logic for non-existent files
- `src/views/Workspace.jsx`: Auto-creation logic when file loading fails with "No such file" error

Limitation: The newly created file does not appear immediately in the file explorer sidebar. Users need to refresh the explorer to see the new file. This is a pre-existing limitation of the file watcher and could be addressed in a follow-up PR.

## 🏷️ Release Notes

<!-- How should this change appear in the release notes? -->
**User-facing changes:**
Clicking a wiki link to a non-existent note now automatically creates the note, as documented. Previously, an error message was displayed. Note: The new file will appear in the explorer after refreshing.

**Developer-facing changes:**
<!-- Describe changes that affect other developers -->

---

**Reviewer notes:**
Please review:
1. Path construction logic in `Editor.jsx` (lines 671-723) - ensures absolute paths for new files
2. Auto-creation logic in `Workspace.jsx` (lines 2123-2150) - creates file on "No such file" error

/cc @maintainers