### PR TITLE
feat: editor improvements with per-tab state isolation and toolbar enhancements

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "visible": false,
         "decorations": true,
         "transparent": false,
+        "hiddenTitle": true,
         "titleBarStyle": "Overlay",
         "alwaysOnTop": false,
         "skipTaskbar": false

--- a/src/components/EditorGroup.jsx
+++ b/src/components/EditorGroup.jsx
@@ -14,6 +14,7 @@ import { registerEditor } from '../stores/editorRegistry';
 // Lazy-loaded special tab views
 const BasesView = lazy(() => import('../bases/BasesView'));
 const ProfessionalGraphView = lazy(() => import('../views/ProfessionalGraphView').then(m => ({ default: m.ProfessionalGraphView })));
+const KanbanBoard = lazy(() => import('./KanbanBoard'));
 
 /**
  * EditorGroup — a single editor pane with its own tabs, content cache,
@@ -32,7 +33,7 @@ export default function EditorGroup({
   group,
   isFocused,
   workspacePath,
-  hideTabBar = false,
+  hideTabBar = false, // kept for WelcomeScreen: true = single group (show welcome), false = split
   onCreateFile,
   onCreateFolder,
   onCreateCanvas,
@@ -76,7 +77,7 @@ export default function EditorGroup({
   const [originalTitle, setOriginalTitle] = useState('');
 
   useEffect(() => {
-    if (!activeFile || activeFile.startsWith('__') || activeFile.endsWith('.canvas')) {
+    if (!activeFile || activeFile.startsWith('__') || activeFile.endsWith('.canvas') || activeFile.endsWith('.kanban')) {
       setEditorTitle('');
       setOriginalTitle('');
       return;
@@ -153,15 +154,15 @@ export default function EditorGroup({
    */
   const snapshotEditorState = useCallback((filePath) => {
     const view = rawEditorRef.current;
-    if (!view || !filePath || filePath.startsWith('__') || filePath.endsWith('.canvas')) return;
+    if (!view || !filePath || filePath.startsWith('__') || filePath.endsWith('.canvas') || filePath.endsWith('.kanban')) return;
     editorStatesRef.current.set(filePath, view.state);
   }, []);
 
   // ── Tab-switching effect ──────────────────────────────────────────────────
 
   useEffect(() => {
-    // Canvas / special files don't involve the ProseMirror instance
-    if (!activeFile || activeFile.startsWith('__') || activeFile.endsWith('.canvas')) {
+    // Canvas / kanban / special files don't involve the ProseMirror instance
+    if (!activeFile || activeFile.startsWith('__') || activeFile.endsWith('.canvas') || activeFile.endsWith('.kanban')) {
       activeFileRef.current = activeFile;
       return;
     }
@@ -174,7 +175,8 @@ export default function EditorGroup({
       prevFile &&
       prevFile !== activeFile &&
       !prevFile.startsWith('__') &&
-      !prevFile.endsWith('.canvas')
+      !prevFile.endsWith('.canvas') &&
+      !prevFile.endsWith('.kanban')
     ) {
       snapshotEditorState(prevFile);
     }
@@ -197,6 +199,13 @@ export default function EditorGroup({
       try {
         const raw = await invoke('read_file_content', { path: activeFile });
         if (cancelled) return;
+
+        // Check if handleEditorReady already loaded this file while we were awaiting
+        if (editorStatesRef.current.has(activeFile)) {
+          setIsLoading(false);
+          restoreEditorState(editorStatesRef.current.get(activeFile));
+          return;
+        }
 
         // Ensure parser is ready
         if (!lokusParserRef.current) {
@@ -285,8 +294,10 @@ export default function EditorGroup({
       }
 
       // If a tab was set active before the editor mounted, load it now.
+      // This handles the case where the component re-mounts after a split
+      // (React changes tree position → unmount/remount → lost EditorView).
       const file = activeFileRef.current;
-      if (file && !file.startsWith('__') && !file.endsWith('.canvas')) {
+      if (file && !file.startsWith('__') && !file.endsWith('.canvas') && !file.endsWith('.kanban')) {
         const cachedState = editorStatesRef.current.get(file);
         if (cachedState) {
           restoreEditorState(cachedState);
@@ -306,6 +317,30 @@ export default function EditorGroup({
               restoreEditorState(newState);
               setIsLoading(false);
             }
+          } else {
+            // No rawMarkdown cached yet — load directly from disk.
+            // This happens after a split when the component re-mounts and
+            // the tab-switching effect's async was cancelled by cleanup.
+            (async () => {
+              try {
+                const raw = await invoke('read_file_content', { path: file });
+                // Verify file is still active and view still exists
+                if (activeFileRef.current !== file || !rawEditorRef.current) return;
+                const doc = lokusParserRef.current.parse(raw);
+                const newState = createEditorStateFromDoc(doc);
+                if (!newState) return;
+                editorStatesRef.current.set(file, newState);
+                useEditorGroupStore.getState().setTabContent(group.id, file, {
+                  savedContent: raw,
+                  title: file.split('/').pop().replace(/\.md$/, ''),
+                });
+                restoreEditorState(newState);
+                setIsLoading(false);
+              } catch (e) {
+                console.error('handleEditorReady: failed to load file:', file, e);
+                setIsLoading(false);
+              }
+            })();
           }
         }
       }
@@ -343,8 +378,9 @@ export default function EditorGroup({
 
   // ── Derived display flags ─────────────────────────────────────────────────
 
-  const isEditorFile = !!(activeFile && !activeFile.startsWith('__') && !activeFile.endsWith('.canvas'));
+  const isEditorFile = !!(activeFile && !activeFile.startsWith('__') && !activeFile.endsWith('.canvas') && !activeFile.endsWith('.kanban'));
   const isCanvasFile = !!(activeFile?.endsWith('.canvas'));
+  const isKanbanFile = !!(activeFile?.endsWith('.kanban'));
   const isBasesTab = activeFile === '__bases__';
   const isGraphTab = activeFile === '__graph__';
 
@@ -355,22 +391,35 @@ export default function EditorGroup({
       className={`flex flex-col h-full relative bg-app-bg ${isFocused ? 'ring-2 ring-app-accent' : ''}`}
       onClick={handleFocus}
     >
-      {/* Tab Bar — hidden in single-pane mode */}
+      {/* Per-pane tab bar — shown in split mode (hideTabBar=false).
+          In single-group mode (hideTabBar=true), tabs are in the Toolbar titlebar instead.
+          In split mode this acts as the titlebar: drag region + panel background. */}
       {!hideTabBar && (
-        <ResponsiveTabBar
-          tabs={tabs}
-          activeTab={activeFile}
-          onTabClick={handleTabClick}
-          onTabClose={handleTabClose}
-          unsavedChanges={unsavedChanges}
-        />
+        <div
+          data-tauri-drag-region
+          style={{
+            backgroundColor: 'rgb(var(--panel))',
+            borderBottom: '1px solid rgb(var(--border))',
+            flexShrink: 0,
+          }}
+        >
+          <ResponsiveTabBar
+            tabs={tabs}
+            activeTab={activeFile}
+            onTabClick={handleTabClick}
+            onTabClose={handleTabClose}
+            unsavedChanges={unsavedChanges}
+          />
+        </div>
       )}
 
       {/* Content Area */}
       <div className="flex-1 min-h-0 overflow-hidden relative">
 
-        {/* Welcome screen — shown when no tab is active */}
-        {!activeFile && (
+        {/* Welcome screen — shown when no tab is active in single-group mode only.
+            In split mode, empty groups auto-close when the last tab is removed.
+            The brief empty state after a fresh split shows a minimal placeholder. */}
+        {!activeFile && hideTabBar && (
           <WelcomeScreen
             onCreateFile={onCreateFile}
             onCreateFolder={onCreateFolder}
@@ -378,6 +427,11 @@ export default function EditorGroup({
             onOpenCommandPalette={onOpenCommandPalette}
             onFileOpen={onFileOpen}
           />
+        )}
+        {!activeFile && !hideTabBar && (
+          <div className="flex-1 flex items-center justify-center text-app-muted text-sm">
+            Open a file to get started
+          </div>
         )}
 
         {/* Canvas viewer — rendered only for .canvas files */}
@@ -396,6 +450,19 @@ export default function EditorGroup({
                 useEditorGroupStore.getState().markTabDirty(group.id, activeFile, true);
               }}
             />
+          </div>
+        )}
+
+        {/* Kanban board — rendered for .kanban files */}
+        {isKanbanFile && (
+          <div className="flex-1 overflow-hidden h-full">
+            <Suspense fallback={<div className="flex-1 flex items-center justify-center text-app-muted">Loading...</div>}>
+              <KanbanBoard
+                workspacePath={workspacePath}
+                boardPath={activeFile}
+                onFileOpen={onFileOpen}
+              />
+            </Suspense>
           </div>
         )}
 

--- a/src/components/TabBar/ResponsiveTabBar.jsx
+++ b/src/components/TabBar/ResponsiveTabBar.jsx
@@ -187,6 +187,7 @@ export function ResponsiveTabBar({
     <div
       ref={containerRef}
       className="responsive-tab-bar"
+      data-tauri-drag-region
       style={{
         width: '100%',
         minWidth: 0,

--- a/src/editor/components/Editor.jsx
+++ b/src/editor/components/Editor.jsx
@@ -80,7 +80,21 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
   const [pluginExtensions, setPluginExtensions] = useState([]);
   const [lastPluginUpdate, setLastPluginUpdate] = useState(0);
   const [customSymbols, setCustomSymbols] = useState({});
+
   const [showSymbolPicker, setShowSymbolPicker] = useState(false);
+
+  // Lazy view ref for suggestion plugins. The proxy forwards all property
+  // accesses to the actual EditorView once it's available. This lets us
+  // create suggestion plugins as static plugins (no onReady reconfigure).
+  const viewRefForPlugins = useRef(null);
+  const viewProxy = useMemo(() => new Proxy({}, {
+    get(_, prop) {
+      const view = viewRefForPlugins.current;
+      if (!view) return undefined;
+      const val = view[prop];
+      return typeof val === 'function' ? val.bind(view) : val;
+    },
+  }), []);
 
   // Reading mode state: 'edit', 'live', 'reading'
   const [editorMode, setEditorMode] = useState(() => {
@@ -212,11 +226,15 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
       ...createMathSnippetsPlugins(schema, { customSnippets: customSymbols }),
       createSymbolShortcutsPlugin({ customSymbols }),
       createMermaidInputRulesPlugin(schema),
+      // Suggestion plugins use a lazy view proxy — they access the
+      // EditorView through the proxy at runtime, so they can be
+      // created statically here (no onReady reconfigure needed).
+      createSlashCommandPlugin(viewProxy),
+      ...createWikiLinkSuggestPlugins(viewProxy),
+      createTagAutocompletePlugin(viewProxy),
+      createTaskMentionSuggestPlugin(viewProxy),
+      createPluginCompletionPlugin(viewProxy),
     ];
-
-    // View-dependent plugins (SlashCommand, WikiLinkSuggest, TagAutocomplete,
-    // TaskMentionSuggest, PluginCompletion) are added in PMEditor's onReady
-    // callback via view.state.reconfigure() since they need the EditorView.
 
     // ── Node views ──────────────────────────────────────────────────────
     const pmNodeViews = {
@@ -227,10 +245,17 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
     };
 
     // ── Load editor settings then finalize ──────────────────────────────
+    // Stale flag: if this effect re-runs before the async work finishes,
+    // the previous invocation's setPlugins is skipped to prevent a late
+    // reconfigure from racing with user interaction.
+    let stale = false;
+
     (async () => {
       try {
         const { readConfig } = await import('../../core/config/store.js');
+        if (stale) return;
         const cfg = (await readConfig()) || {};
+        if (stale) return;
 
         // Load editor settings
         const defaultEditorSettings = {
@@ -273,6 +298,7 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
         setEditorSettings(mergedSettings);
 
       } catch (e) {
+        if (stale) return;
         // Use defaults if loading fails
         setEditorSettings({
           font: { family: 'ui-sans-serif', size: 16, lineHeight: 1.7, letterSpacing: 0.003 },
@@ -282,10 +308,13 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
         });
       }
 
+      if (stale) return;
       setPlugins(pmPlugins);
       setNodeViews(pmNodeViews);
       setLoading(false);
     })();
+
+    return () => { stale = true; };
   }, [pluginExtensions, lastPluginUpdate, customSymbols]);
 
   // Load custom symbols from config and listen for changes
@@ -387,6 +416,7 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
       showSymbolPicker={showSymbolPicker}
       setShowSymbolPicker={setShowSymbolPicker}
       customSymbols={customSymbols}
+      viewRefForPlugins={viewRefForPlugins}
     />
   );
 });
@@ -398,7 +428,7 @@ const Editor = forwardRef(({ content, onContentChange, onEditorReady, isLoading 
 // renders the editor mount point.
 // ---------------------------------------------------------------------------
 
-const PMEditor = forwardRef(({ plugins, nodeViews, content, onContentChange, editorSettings, editorMode = 'edit', onEditorReady, isLoading = false, showSymbolPicker = false, setShowSymbolPicker, customSymbols = {} }, ref) => {
+const PMEditor = forwardRef(({ plugins, nodeViews, content, onContentChange, editorSettings, editorMode = 'edit', onEditorReady, isLoading = false, showSymbolPicker = false, setShowSymbolPicker, customSymbols = {}, viewRefForPlugins }, ref) => {
   const [isWikiLinkModalOpen, setIsWikiLinkModalOpen] = useState(false);
   const [isTaskCreationModalOpen, setIsTaskCreationModalOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
@@ -647,28 +677,13 @@ const PMEditor = forwardRef(({ plugins, nodeViews, content, onContentChange, edi
       },
     },
     onReady: (view) => {
+      // Wire up the lazy view proxy so suggestion plugins can access the view.
+      if (viewRefForPlugins) viewRefForPlugins.current = view;
       editorAPI.setEditorInstance(view);
       onEditorReady?.(view);
-
-      // Create view-dependent plugins (suggestion-based) now that the view exists
-      try {
-        const viewPlugins = [
-          createSlashCommandPlugin(view),
-          ...createWikiLinkSuggestPlugins(view),
-          createTagAutocompletePlugin(view),
-          createTaskMentionSuggestPlugin(view),
-          createPluginCompletionPlugin(view),
-        ];
-        // Reconfigure state to add these plugins alongside the static ones
-        const newState = view.state.reconfigure({
-          plugins: [...view.state.plugins, ...viewPlugins],
-        });
-        view.updateState(newState);
-      } catch (err) {
-        console.error('[PMEditor] Failed to initialize view-dependent plugins:', err);
-      }
     },
     onDestroy: () => {
+      if (viewRefForPlugins) viewRefForPlugins.current = null;
       editorAPI.setEditorInstance(null);
       onEditorReady?.(null);
     },

--- a/src/editor/components/SlashCommandList.jsx
+++ b/src/editor/components/SlashCommandList.jsx
@@ -118,7 +118,7 @@ const SlashCommandList = forwardRef((props, ref) => {
                         : ""
                     }
                   >
-                    <div className="flex items-center justify-center w-7 h-7 bg-app-bg rounded-md mr-3">
+                    <div className="flex items-center justify-center w-7 h-7 bg-app-bg rounded-md mr-3 !text-app-text">
                       {item.icon}
                     </div>
                     <div className="flex flex-col">

--- a/src/editor/hooks/useProseMirror.js
+++ b/src/editor/hooks/useProseMirror.js
@@ -267,15 +267,9 @@ export default function useProseMirror({
     const view = viewRef.current;
     if (!view) return;
 
-    // On the initial mount, plugins are already set from creation.
-    // This effect only matters for subsequent changes.
-    // We compare against what the view currently has.
     const currentPlugins = view.state.plugins;
     if (plugins === currentPlugins) return;
 
-    // Skip reconfiguration if the array reference hasn't changed.
-    // (pluginsRef.current is updated during render, but this effect
-    // compares the prop value directly.)
     const newState = view.state.reconfigure({ plugins });
     view.updateState(newState);
   }, [plugins]);

--- a/src/editor/lib/react-pm-helpers.jsx
+++ b/src/editor/lib/react-pm-helpers.jsx
@@ -108,15 +108,13 @@ export class ReactPopup {
 
   _render() {
     const Component = this._Component
-    const innerRef = this._innerRef
 
-    // We use a thin wrapper so we can capture the ref without modifying the
-    // caller's props object or requiring the Component to accept a special prop.
-    const Wrapper = () => (
-      <Component ref={innerRef} {...this._props} />
+    // Render the component directly (not via a wrapper function) so that
+    // React sees the same component type on every call and UPDATES rather
+    // than REMOUNTING. This preserves the imperative ref across re-renders.
+    this._root.render(
+      <Component ref={this._innerRef} {...this._props} />
     )
-
-    this._root.render(<Wrapper />)
   }
 }
 

--- a/src/editor/lib/slash-command.jsx
+++ b/src/editor/lib/slash-command.jsx
@@ -930,7 +930,7 @@ const slashCommand = {
           items: currentItems
         };
 
-        component.updateProps(enhancedProps);
+        component?.updateProps(enhancedProps);
 
         if (!props.clientRect) {
           logger.warn('SlashCommand', 'No clientRect in onUpdate');
@@ -957,7 +957,7 @@ const slashCommand = {
           return true;
         }
 
-        return component.ref?.onKeyDown(props);
+        return component?.ref?.onKeyDown(props);
       },
 
       onExit() {

--- a/src/editor/lib/suggestion-plugin.js
+++ b/src/editor/lib/suggestion-plugin.js
@@ -298,8 +298,8 @@ export function createSuggestionPlugin({
     view() {
       return {
         update: async (view, prevState) => {
-          const prev = plugin.key?.getState(prevState);
-          const next = plugin.key?.getState(view.state);
+          const prev = pluginKey.getState(prevState);
+          const next = pluginKey.getState(view.state);
 
           if (!prev || !next) return;
 
@@ -354,6 +354,15 @@ export function createSuggestionPlugin({
               editor,
               query: state.query,
             });
+
+            // After the async item fetch, the state may have changed
+            // (e.g., user typed more, suggestion was dismissed, or a
+            // plugin reconfiguration occurred). Re-check current state
+            // to avoid acting on stale data.
+            const currentState = pluginKey.getState(view.state);
+            if (!currentState?.active) {
+              return;
+            }
           }
 
           if (handleExit) {

--- a/src/stores/editorGroups.js
+++ b/src/stores/editorGroups.js
@@ -100,15 +100,31 @@ export const useEditorGroupStore = create(
       })),
 
     removeTab: (groupId, tabPath) =>
-      set((s) => ({
-        layout: updateGroupInTree(s.layout, groupId, (g) => {
+      set((s) => {
+        const updatedLayout = updateGroupInTree(s.layout, groupId, (g) => {
           const newTabs = g.tabs.filter((t) => t.path !== tabPath);
           const newActive = g.activeTab === tabPath ? (newTabs[0]?.path || null) : g.activeTab;
           const newContent = { ...g.contentByTab };
           delete newContent[tabPath];
           return { ...g, tabs: newTabs, activeTab: newActive, contentByTab: newContent };
-        }),
-      })),
+        });
+
+        // Auto-close empty split groups (like VS Code)
+        const group = findGroupInTree(updatedLayout, groupId);
+        if (group && group.tabs.length === 0 && updatedLayout.type === 'container') {
+          const result = removeGroupFromTree(updatedLayout, groupId);
+          // Find a remaining group to focus
+          const findFirstGroup = (node) => {
+            if (node.type === 'group') return node.id;
+            if (node.type === 'container' && node.children.length > 0) return findFirstGroup(node.children[0]);
+            return null;
+          };
+          const newLayout = result || createGroup([], null);
+          return { layout: newLayout, focusedGroupId: findFirstGroup(newLayout) || s.focusedGroupId };
+        }
+
+        return { layout: updatedLayout };
+      }),
 
     setActiveTab: (groupId, tabPath) =>
       set((s) => ({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1707,6 +1707,15 @@ div:focus-visible,
   padding-left: 80px; /* Space for traffic lights on the left */
 }
 
+/* Split mode — collapse the app-titlebar so panes extend to the top of the window.
+   Each pane's tab bar serves as the titlebar in split mode. */
+.split-mode .app-titlebar {
+  height: 0;
+  min-height: 0;
+  border: none;
+  overflow: hidden;
+}
+
 .app-content {
   flex: 1;
   overflow: hidden;

--- a/src/views/WorkspaceShell.jsx
+++ b/src/views/WorkspaceShell.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useLayoutStore } from '../stores/layout';
+import { useEditorGroupStore } from '../stores/editorGroups';
+import { useColumnResize } from '../features/layout';
 
 /**
  * WorkspaceShell — pure CSS grid layout container.
@@ -35,6 +37,16 @@ export default function WorkspaceShell({
   const bottomPanelHeight = useLayoutStore((s) => s.bottomPanelHeight);
 
   const showBottom = showTerminalPanel || showOutputPanel;
+  const { startLeftDrag, startRightDrag } = useColumnResize({});
+
+  // In split mode, collapse toolbar row so panes extend to the very top.
+  // Also toggle a body class so the app-titlebar (in App.jsx) collapses too.
+  const isSplitMode = useEditorGroupStore((s) => s.layout.type !== 'group');
+
+  React.useEffect(() => {
+    document.body.classList.toggle('split-mode', isSplitMode);
+    return () => document.body.classList.remove('split-mode');
+  }, [isSplitMode]);
 
   const gridTemplateColumns = [
     '48px',                                    // icon-sidebar — always visible
@@ -44,7 +56,7 @@ export default function WorkspaceShell({
   ].join(' ');
 
   const gridTemplateRows = [
-    'auto',                                    // toolbar
+    isSplitMode ? '0px' : 'auto',              // toolbar — collapsed in split mode
     '1fr',                                     // main content expands here
     showBottom ? `${bottomPanelHeight}px` : '0px', // bottom-panel
     'auto',                                    // status-bar
@@ -80,8 +92,22 @@ export default function WorkspaceShell({
       </div>
 
       {/* ── left-sidebar ── */}
-      <div style={{ gridArea: 'left-sidebar', minWidth: 0, overflow: 'hidden' }}>
+      <div style={{ gridArea: 'left-sidebar', minWidth: 0, overflow: 'hidden', position: 'relative' }}>
         {showLeft && leftSidebar}
+        {showLeft && (
+          <div
+            onMouseDown={startLeftDrag}
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              width: 4,
+              height: '100%',
+              cursor: 'col-resize',
+              zIndex: 10,
+            }}
+          />
+        )}
       </div>
 
       {/* ── main content ── */}
@@ -95,8 +121,22 @@ export default function WorkspaceShell({
       </div>
 
       {/* ── right-sidebar ── */}
-      <div style={{ gridArea: 'right-sidebar', minWidth: 0, overflow: 'hidden' }}>
+      <div style={{ gridArea: 'right-sidebar', minWidth: 0, overflow: 'hidden', position: 'relative' }}>
         {showRight && rightSidebar}
+        {showRight && (
+          <div
+            onMouseDown={startRightDrag}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 4,
+              height: '100%',
+              cursor: 'col-resize',
+              zIndex: 10,
+            }}
+          />
+        )}
       </div>
 
       {/* ── status-bar ── */}

--- a/src/views/workspace/LeftSidebar.jsx
+++ b/src/views/workspace/LeftSidebar.jsx
@@ -7,8 +7,6 @@ import { useFeatureFlags } from '../../contexts/RemoteConfigContext';
 import { FileTreeView } from '../../features/file-tree';
 import PluginSettings from '../PluginSettings.jsx';
 import KanbanList from '../../components/KanbanList.jsx';
-import { DailyNotesPanel } from '../../components/DailyNotes/index.js';
-import { CalendarWidget } from '../../components/Calendar/index.js';
 import { toast } from '../../components/ui/enhanced-toast';
 import { formatAccelerator } from '../../core/shortcuts/registry.js';
 import { isDesktop } from '../../platform/index.js';
@@ -24,10 +22,9 @@ import {
  * LeftSidebar — the resizable left panel.
  *
  * Shows the file explorer by default, and conditionally renders
- * DailyNotesPanel, CalendarWidget, KanbanList, or PluginSettings
- * based on the active view from useViewStore and panel flags.
- * Bases and Graph views render only in MainContent — the sidebar
- * stays as the file explorer for those views.
+ * KanbanList or PluginSettings based on the active view.
+ * Daily Notes and Calendar render only in the right sidebar.
+ * Bases and Graph render as tabs in EditorGroup.
  */
 export default function LeftSidebar({
   workspacePath,
@@ -52,9 +49,6 @@ export default function LeftSidebar({
 
   // View state from useViewStore
   const currentView = useViewStore((s) => s.currentView);
-  const showDailyNotesPanel = useViewStore((s) => s.showDailyNotesPanel);
-  const showCalendarPanel = useViewStore((s) => s.showCalendarPanel);
-  const currentDailyNoteDate = useViewStore((s) => s.currentDailyNoteDate);
 
   // Derive boolean view flags from currentView
   const showKanban = currentView === 'kanban';
@@ -91,31 +85,6 @@ export default function LeftSidebar({
   const toggleFolder = (path) => useFileTreeStore.getState().toggleFolder(path);
   const closeAllFolders = () => useFileTreeStore.getState().closeAllFolders();
 
-  const handleOpenCalendarView = () => {
-    const calendarPath = '__calendar__';
-    const calendarName = 'Calendar';
-    const { focusedGroupId } = useEditorGroupStore.getState();
-    if (focusedGroupId) {
-      useEditorGroupStore.getState().addTab(
-        focusedGroupId,
-        { path: calendarPath, name: calendarName },
-        true
-      );
-    }
-  };
-
-  const handleOpenCalendarSettings = async () => {
-    try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      await invoke('open_preferences_window', {
-        workspacePath,
-        section: 'Connections',
-      });
-    } catch (e) {
-      console.error('Failed to open preferences:', e);
-    }
-  };
-
   // Plugins panel
   if (featureFlags.enable_plugins && showPlugins) {
     return (
@@ -137,35 +106,6 @@ export default function LeftSidebar({
             onBoardOpen={onFileOpen}
             onCreateBoard={onCreateKanban}
             onBoardAction={onKanbanBoardAction}
-          />
-        </div>
-      </aside>
-    );
-  }
-
-  // Daily notes panel
-  if (showDailyNotesPanel) {
-    return (
-      <aside className="h-full overflow-y-auto flex flex-col bg-app-bg border-r border-app-border">
-        <div className="flex-1 overflow-hidden">
-          <DailyNotesPanel
-            workspacePath={workspacePath}
-            onOpenDailyNote={onOpenDailyNoteByDate}
-            currentDate={currentDailyNoteDate}
-          />
-        </div>
-      </aside>
-    );
-  }
-
-  // Calendar widget panel
-  if (showCalendarPanel) {
-    return (
-      <aside className="h-full overflow-y-auto flex flex-col bg-app-bg border-r border-app-border">
-        <div className="flex-1 overflow-hidden">
-          <CalendarWidget
-            onOpenCalendarView={handleOpenCalendarView}
-            onOpenSettings={handleOpenCalendarSettings}
           />
         </div>
       </aside>

--- a/src/views/workspace/MainContent.jsx
+++ b/src/views/workspace/MainContent.jsx
@@ -3,7 +3,6 @@ import { useViewStore } from '../../stores/views';
 import ErrorBoundary from '../../components/ErrorBoundary';
 
 const EditorGroupsView = lazy(() => import('./EditorGroupsView'));
-const KanbanBoard = lazy(() => import('../../components/KanbanBoard'));
 const CalendarView = lazy(() => import('../../components/Calendar').then(m => ({ default: m.CalendarView })));
 const Canvas = lazy(() => import('../Canvas'));
 const Preferences = lazy(() => import('../Preferences'));
@@ -14,19 +13,19 @@ export default function MainContent({ workspacePath, welcomeProps }) {
 
   const fallback = <div className="flex-1 flex items-center justify-center text-app-muted">Loading...</div>;
 
-  // Bases and Graph are rendered as tabs inside EditorGroupsView,
-  // not as separate full-screen views. They open via addTab('__bases__')
-  // and addTab('__graph__') in IconSidebar.
+  // Kanban boards open as .kanban tabs inside EditorGroupsView.
+  // The kanban icon sidebar button switches the left sidebar to the board list,
+  // but keeps EditorGroupsView as the main content.
+  const showEditor = currentView === 'editor' || currentView === 'kanban' || currentView === 'marketplace';
+
   return (
     <ErrorBoundary name="MainContent" message="View crashed">
       <Suspense fallback={fallback}>
-        {currentView === 'editor' && <EditorGroupsView workspacePath={workspacePath} welcomeProps={welcomeProps} />}
-        {currentView === 'kanban' && <KanbanBoard workspacePath={workspacePath} />}
+        {showEditor && <EditorGroupsView workspacePath={workspacePath} welcomeProps={welcomeProps} />}
         {currentView === 'calendar' && <CalendarView />}
         {currentView === 'canvas' && <Canvas workspacePath={workspacePath} />}
         {currentView === 'settings' && <Preferences workspacePath={workspacePath} />}
         {currentView === 'dailyNotes' && <DailyNotesPanel workspacePath={workspacePath} />}
-        {currentView === 'marketplace' && <div className="flex-1 flex items-center justify-center text-app-muted">Marketplace coming soon</div>}
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/views/workspace/Toolbar.jsx
+++ b/src/views/workspace/Toolbar.jsx
@@ -53,8 +53,12 @@ export default function Toolbar({
     return findGroup(layout);
   });
 
+  // Single group = tabs in titlebar. Split = each pane has its own tab bar.
+  const isSingleGroup = useEditorGroupStore((s) => s.layout.type === 'group');
+
   const openTabs = focusedGroup?.tabs ?? [];
   const activeFile = focusedGroup?.activeTab ?? null;
+  const hasActiveTabs = openTabs.length > 0;
   const unsavedChanges = new Set(
     Object.entries(focusedGroup?.contentByTab ?? {})
       .filter(([, data]) => data?.dirty)
@@ -75,6 +79,64 @@ export default function Toolbar({
     }
   };
 
+  // ── Split mode: panes extend to the top, each pane has its own tab bar.
+  //    Only render a small floating overlay with action buttons at top-right. ──
+  if (!isSingleGroup) {
+    return (
+      <div
+        className="fixed top-0 right-0 flex items-center gap-1 z-50"
+        data-tauri-drag-region
+        style={{
+          height: '32px',
+          paddingRight: '8px',
+          paddingLeft: '8px',
+          backgroundColor: 'rgb(var(--panel) / 0.85)',
+          borderBottomLeftRadius: '6px',
+          backdropFilter: 'blur(8px)',
+        }}
+      >
+        {uiVisibility.toolbar_split_view && hasActiveTabs && (
+          <button
+            onClick={() => {
+              const { focusedGroupId, splitGroup } = useEditorGroupStore.getState();
+              if (focusedGroupId) splitGroup(focusedGroupId, 'vertical');
+            }}
+            className="obsidian-button icon-only small"
+            title="Split View"
+            data-tauri-drag-region="false"
+            data-tour="split-view"
+            style={{ pointerEvents: 'auto' }}
+          >
+            <SquareSplitHorizontal className="w-5 h-5" strokeWidth={2} />
+          </button>
+        )}
+        <button
+          onClick={() => useLayoutStore.getState().toggleRight()}
+          className={`obsidian-button icon-only small ${showRight ? 'active' : ''}`}
+          title={showRight ? 'Hide Right Sidebar' : 'Show Right Sidebar'}
+          data-tauri-drag-region="false"
+          style={{ pointerEvents: 'auto' }}
+        >
+          {showRight ? (
+            <PanelRightClose className="w-5 h-5" strokeWidth={2} />
+          ) : (
+            <PanelRightOpen className="w-5 h-5" strokeWidth={2} />
+          )}
+        </button>
+        <button
+          onClick={onCreateFile}
+          className="obsidian-button icon-only small"
+          title="New Tab"
+          data-tauri-drag-region="false"
+          style={{ pointerEvents: 'auto' }}
+        >
+          <Plus className="w-5 h-5" strokeWidth={2.5} />
+        </button>
+      </div>
+    );
+  }
+
+  // ── Single-group mode: full toolbar bar with tab bar in the titlebar ──
   return (
     <div
       className="fixed top-0 left-0 right-0 flex items-center justify-between z-50"
@@ -125,9 +187,10 @@ export default function Toolbar({
         )}
       </div>
 
-      {/* Center: responsive tab bar */}
+      {/* Center: tab bar in titlebar */}
       <div
         className="absolute flex items-center overflow-hidden px-2"
+        data-tauri-drag-region
         style={{
           left: showLeft
             ? `${leftW + 57}px`
@@ -149,7 +212,7 @@ export default function Toolbar({
 
       {/* Right: split view toggle, sidebar toggle, new tab */}
       <div className="flex items-center gap-1">
-        {uiVisibility.toolbar_split_view && (
+        {uiVisibility.toolbar_split_view && hasActiveTabs && (
           <button
             onClick={() => {
               const { focusedGroupId, splitGroup } = useEditorGroupStore.getState();


### PR DESCRIPTION
## Summary
- Per-tab EditorState isolation — each tab gets independent undo history, cursor position, and editor state
- Kanban board support in editor groups (`.kanban` files)
- View-switching controls (Bases, Graph) moved from sidebar to toolbar for cleaner UX
- Slash command positioning and suggestion plugin fixes
- ProseMirror helpers and editor lifecycle improvements

## Test plan
- [ ] Open multiple tabs and verify undo/redo is isolated per tab
- [ ] Switch between tabs and confirm cursor position is restored
- [ ] Test slash commands work correctly with updated positioning
- [ ] Verify Bases and Graph views accessible from toolbar
- [ ] Test kanban file opening in editor groups