### PR TITLE
feat: add guest mode for local-only usage

### DIFF
--- a/src/components/Auth/AuthButton.jsx
+++ b/src/components/Auth/AuthButton.jsx
@@ -4,7 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useAuth } from '../../core/auth/AuthContext';
 
 export default function AuthButton() {
-  const { isAuthenticated, user, signIn, signOut, isLoading } = useAuth();
+  const { isAuthenticated, user, signIn, signOut, isGuest, isLoading } = useAuth();
   const [showDropdown, setShowDropdown] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
 
@@ -49,6 +49,61 @@ export default function AuthButton() {
         <LogIn className="w-4 h-4" />
         <span className="hidden sm:inline">Sign In</span>
       </button>
+    );
+  }
+
+  // Guest mode: show Guest label with option to sign in
+  if (isGuest) {
+    return (
+      <div className="relative">
+        <button
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="flex items-center gap-2 px-2 py-1.5 text-sm bg-app-panel hover:bg-app-panel/80 border border-app-border rounded-md transition-colors"
+          title="Guest"
+        >
+          <div className="w-6 h-6 bg-app-muted/30 rounded-full flex items-center justify-center">
+            <User className="w-4 h-4 text-app-muted" />
+          </div>
+          <span className="hidden sm:inline text-app-muted">Guest</span>
+        </button>
+
+        {showDropdown && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setShowDropdown(false)}
+            />
+            <div className="absolute right-0 top-full mt-1 w-48 bg-app-panel border border-app-border rounded-md shadow-lg z-20">
+              <div className="p-3 border-b border-app-border">
+                <div className="font-medium text-app-text text-sm">Guest</div>
+                <div className="text-xs text-app-muted">Not signed in</div>
+              </div>
+              <div className="py-1">
+                <button
+                  className="w-full px-3 py-2 text-left text-sm text-app-text hover:bg-app-bg flex items-center gap-2"
+                  onClick={() => {
+                    setShowDropdown(false);
+                    handleSignOut(); // Clears guest mode → returns to login screen
+                  }}
+                >
+                  <LogIn className="w-4 h-4" />
+                  Sign in to sync
+                </button>
+                <button
+                  className="w-full px-3 py-2 text-left text-sm text-app-text hover:bg-app-bg flex items-center gap-2"
+                  onClick={() => {
+                    setShowDropdown(false);
+                    invoke('open_preferences_window', { workspacePath: window.__WORKSPACE_PATH__ || null });
+                  }}
+                >
+                  <Settings className="w-4 h-4" />
+                  Account Settings
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
     );
   }
 

--- a/src/core/auth/AuthContext.jsx
+++ b/src/core/auth/AuthContext.jsx
@@ -16,6 +16,7 @@ export const AuthProvider = ({ children }) => {
   const [authState, setAuthState] = useState({
     isAuthenticated: false,
     user: null,
+    isGuest: false,
     isLoading: true
   });
 
@@ -28,13 +29,14 @@ export const AuthProvider = ({ children }) => {
           ...prev,
           isAuthenticated: newState.isAuthenticated,
           user: newState.user,
+          isGuest: newState.isGuest,
           isLoading: false
         };
         return newAuthState;
       });
 
-      // Identify user in PostHog when authenticated
-      if (newState.isAuthenticated && newState.user) {
+      // Identify user in PostHog when authenticated (skip for guests — they get anonymous tracking)
+      if (newState.isAuthenticated && newState.user && !newState.isGuest) {
         posthog.identify(newState.user.id, {
           email: newState.user.email
         });
@@ -48,6 +50,7 @@ export const AuthProvider = ({ children }) => {
           ...prev,
           isAuthenticated: authManager.isLoggedIn,
           user: authManager.currentUser,
+          isGuest: authManager.isGuest,
           isLoading: false
         };
         return newAuthState;
@@ -114,6 +117,11 @@ export const AuthProvider = ({ children }) => {
     return await authManager.authenticatedFetch(url, options);
   };
 
+  // Continue as guest
+  const continueAsGuest = () => {
+    authManager.continueAsGuest();
+  };
+
   // Reset password
   const resetPassword = async (email) => {
     try {
@@ -130,6 +138,7 @@ export const AuthProvider = ({ children }) => {
     signUpWithEmail,
     signInWithGoogle,
     signOut,
+    continueAsGuest,
     getAccessToken,
     authenticatedFetch,
     resetPassword

--- a/src/core/auth/AuthManager.js
+++ b/src/core/auth/AuthManager.js
@@ -8,6 +8,7 @@ class AuthManager {
     this.user = null;
     this.session = null;
     this.isAuthenticated = false;
+    this.isGuest = false;
     this.isInitialized = false;
 
     // Throttling for auth checks to prevent excessive calls
@@ -31,9 +32,9 @@ class AuthManager {
         email: 'dev@localhost',
         user_metadata: { name: 'Local Developer' }
       };
-      this.session = { 
+      this.session = {
         access_token: 'local-dev-token',
-        user: this.user 
+        user: this.user
       };
       this.isAuthenticated = true;
       this.isInitialized = true;
@@ -41,9 +42,21 @@ class AuthManager {
       return;
     }
 
+    // Check for persisted guest mode
+    if (localStorage.getItem('lokus-guest-mode') === 'true') {
+      console.log('[AuthManager] Restoring guest mode from localStorage');
+      this._enterGuestMode();
+      return;
+    }
+
     // Set up Supabase auth state listener
     supabase.auth.onAuthStateChange((event, session) => {
       console.log('[AuthManager] Auth state changed:', event, session?.user?.email);
+
+      // Real sign-in clears guest mode
+      if (session && this.isGuest) {
+        this._clearGuestMode();
+      }
 
       this.session = session;
       this.user = session?.user || null;
@@ -84,11 +97,16 @@ class AuthManager {
 
   async checkAuthStatus() {
     // Check for local dev mode
-    const isLocalDev = import.meta.env.VITE_LOCAL_DEV_MODE === 'true' || 
+    const isLocalDev = import.meta.env.VITE_LOCAL_DEV_MODE === 'true' ||
                        import.meta.env.DEV && import.meta.env.VITE_SUPABASE_URL?.includes('dummy');
-    
+
     if (isLocalDev) {
       // Always return authenticated in local dev mode
+      return true;
+    }
+
+    // Guest mode — no Supabase session to check
+    if (this.isGuest) {
       return true;
     }
 
@@ -349,6 +367,16 @@ class AuthManager {
    */
   async signOut() {
     try {
+      // If guest, just clear guest mode — no Supabase session to revoke
+      if (this.isGuest) {
+        this._clearGuestMode();
+        this.isAuthenticated = false;
+        this.user = null;
+        this.session = null;
+        this.notifyListeners();
+        return;
+      }
+
       const { error } = await supabase.auth.signOut();
 
       if (error) {
@@ -444,6 +472,29 @@ class AuthManager {
     }
   }
 
+  /**
+   * Continue as guest — bypasses Supabase auth entirely
+   */
+  continueAsGuest() {
+    console.log('[AuthManager] Entering guest mode');
+    this._enterGuestMode();
+  }
+
+  _enterGuestMode() {
+    this.isGuest = true;
+    this.isAuthenticated = true;
+    this.user = { id: 'guest', email: null, user_metadata: { name: 'Guest' } };
+    this.session = null;
+    this.isInitialized = true;
+    localStorage.setItem('lokus-guest-mode', 'true');
+    this.notifyListeners();
+  }
+
+  _clearGuestMode() {
+    this.isGuest = false;
+    localStorage.removeItem('lokus-guest-mode');
+  }
+
   // Event system for auth state changes
   onAuthStateChange(callback) {
     this.listeners.add(callback);
@@ -452,7 +503,8 @@ class AuthManager {
     if (this.isInitialized) {
       callback({
         isAuthenticated: this.isAuthenticated,
-        user: this.user
+        user: this.user,
+        isGuest: this.isGuest
       });
     }
 
@@ -467,7 +519,8 @@ class AuthManager {
       try {
         callback({
           isAuthenticated: this.isAuthenticated,
-          user: this.user
+          user: this.user,
+          isGuest: this.isGuest
         });
       } catch (err) {
         console.error('[AuthManager] Listener error:', err);

--- a/src/views/LoginScreen.jsx
+++ b/src/views/LoginScreen.jsx
@@ -3,7 +3,7 @@ import { useAuth } from "../core/auth/AuthContext.jsx";
 import LokusLogo from "../components/LokusLogo.jsx";
 
 export default function LoginScreen() {
-  const { signInWithEmail, signUpWithEmail, signInWithGoogle, resetPassword, isLoading } = useAuth();
+  const { signInWithEmail, signUpWithEmail, signInWithGoogle, resetPassword, continueAsGuest, isLoading } = useAuth();
 
   const [mode, setMode] = useState('signin'); // 'signin', 'signup', 'reset'
   const [email, setEmail] = useState('');
@@ -287,6 +287,24 @@ export default function LoginScreen() {
               Back to sign in
             </button>
           )}
+        </div>
+
+        {/* Continue as Guest */}
+        <div className="mt-8">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="flex-1 h-px bg-app-border"></div>
+            <span className="text-app-muted text-sm">or</span>
+            <div className="flex-1 h-px bg-app-border"></div>
+          </div>
+          <button
+            onClick={continueAsGuest}
+            className="w-full px-4 py-2.5 rounded-lg border border-app-border text-app-text hover:bg-app-panel transition-colors"
+          >
+            Continue as Guest
+          </button>
+          <p className="text-center text-xs text-app-muted mt-2">
+            Your notes stay on this device
+          </p>
         </div>
       </div>
     </div>

--- a/src/views/Preferences.jsx
+++ b/src/views/Preferences.jsx
@@ -33,7 +33,7 @@ export default function Preferences() {
   const [originalTokens, setOriginalTokens] = useState({});
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [section, setSection] = useState("Appearance");
-  const { isAuthenticated, user, signIn, signOut, isLoading, getAccessToken } = useAuth();
+  const { isAuthenticated, user, signIn, signOut, isLoading, isGuest, getAccessToken } = useAuth();
   const featureFlags = useFeatureFlags();
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [showQuickImport, setShowQuickImport] = useState(false);
@@ -3178,6 +3178,30 @@ export default function Preferences() {
                 {isLoading ? (
                   <div className="flex items-center justify-center py-12">
                     <div className="w-6 h-6 border-2 border-app-accent border-t-transparent rounded-full animate-spin"></div>
+                  </div>
+                ) : isGuest ? (
+                  /* Guest Mode State */
+                  <div className="bg-app-panel border border-app-border rounded-xl p-8">
+                    <div className="text-center">
+                      <div className="w-16 h-16 bg-app-muted/20 rounded-full flex items-center justify-center mx-auto mb-6">
+                        <User className="w-8 h-8 text-app-muted" />
+                      </div>
+                      <h2 className="text-xl font-semibold text-app-text mb-3">Guest Mode</h2>
+                      <p className="text-app-text-secondary mb-8 max-w-md mx-auto">
+                        You're using Lokus as a guest. Sign in to sync your notes across devices.
+                      </p>
+                      <button
+                        onClick={async () => {
+                          try {
+                            await signOut(); // Clears guest mode → returns to login screen
+                          } catch { }
+                        }}
+                        className="inline-flex items-center gap-2 px-6 py-3 bg-app-accent text-white font-medium rounded-lg hover:bg-app-accent/90 transition-colors"
+                      >
+                        <LogIn className="w-4 h-4" />
+                        Sign In
+                      </button>
+                    </div>
                   </div>
                 ) : !isAuthenticated ? (
                   /* Sign In State */


### PR DESCRIPTION
## Summary
- Adds "Continue as Guest" button on the login screen for users who want local-only usage
- Guest mode persists across app restarts via localStorage
- Full app access without requiring a Supabase account
- AuthButton and Preferences show guest state with option to sign in later
- Signing in with real credentials automatically clears guest mode

## Test plan
- [ ] Click "Continue as Guest" on login screen — should enter the app
- [ ] Restart the app — should remain in guest mode
- [ ] Click "Sign in to sync" from guest dropdown — should return to login
- [ ] Sign in with real account while in guest mode — should clear guest state
- [ ] Verify PostHog does not identify guest users