### PR TITLE
fix(build): exclude Node-only graphIndex from the client bundle

### DIFF
--- a/src/mcp-server/utils/graphIndex.browser.js
+++ b/src/mcp-server/utils/graphIndex.browser.js
@@ -1,0 +1,42 @@
+/**
+ * Browser stub for graphIndex.js
+ *
+ * The real graphIndex.js imports Node builtins (fs/promises, path) and walks the
+ * workspace on disk. Those builtins do not exist in the WebKit renderer, so the
+ * production browser bundle uses this stub instead (wired via resolve.alias in
+ * vite.config.js). The Node/MCP-server build still bundles the real module.
+ *
+ * The renderer only calls: getGraphIndex(ws) -> { load(), getRelatedNotes() }.
+ * Graph-backed suggestions degrade to empty; the rest of the app is unaffected.
+ */
+
+class GraphIndex {
+  constructor(workspacePath) {
+    this.workspacePath = workspacePath;
+    this.graph = null;
+  }
+
+  async load() {
+    return this.graph;
+  }
+
+  getRelatedNotes() {
+    return { found: false, related: [] };
+  }
+
+  getBacklinks() {
+    return [];
+  }
+}
+
+const instances = new Map();
+
+export function getGraphIndex(workspacePath) {
+  if (!instances.has(workspacePath)) {
+    instances.set(workspacePath, new GraphIndex(workspacePath));
+  }
+  return instances.get(workspacePath);
+}
+
+export { GraphIndex };
+export default { GraphIndex, getGraphIndex };

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,10 +8,19 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "jsxgraph/distrib/jsxgraph.css": path.resolve(__dirname, "node_modules/jsxgraph/distrib/jsxgraph.css"),
-    },
+    // Array form so the graphIndex entry can use a regex `find`.
+    alias: [
+      // graphIndex.js statically imports Node builtins (fs/promises, path), which
+      // cannot resolve in the browser/client bundle and break the production build.
+      // Redirect it to a browser-safe stub here; the Node/MCP-server esbuild bundle
+      // is separate and still uses the real module.
+      {
+        find: /^.*[\\/]graphIndex\.js$/,
+        replacement: path.resolve(__dirname, "./src/mcp-server/utils/graphIndex.browser.js"),
+      },
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+      { find: "jsxgraph/distrib/jsxgraph.css", replacement: path.resolve(__dirname, "node_modules/jsxgraph/distrib/jsxgraph.css") },
+    ],
   },
 
   // Excalidraw 0.18+ uses `export { english as "en-us" }` in locale modules


### PR DESCRIPTION
## 📝 Description

**What type of PR is this?**
- [x] 🐛 Bug fix

**What does this PR do?**

`src/mcp-server/utils/graphIndex.js` imports Node builtins (`fs/promises`, `path`) at the top level and is pulled into the client bundle through three renderer components (`ContextAssembler`, `actionContext`, `ResurfacingProvider`). Vite externalizes those builtins to an empty browser shim with no named exports, so `npm run build` fails at rollup link:

```
"join" is not exported by "__vite-browser-external", imported by src/mcp-server/utils/graphIndex.js
```

This adds a browser-safe stub (`graphIndex.browser.js`) and aliases `graphIndex.js` to it in the client build only (via `resolve.alias`). The Node/MCP-server esbuild bundle is separate and keeps the real module, so the MCP graph index is unchanged on the Node side.

Being upfront about the tradeoff: the graph-backed "related notes" suggestions degrade to empty in the renderer. As far as I can tell they could not run there anyway, `GraphIndex.load()` needs Node `fs`, which the Tauri webview does not have (`ResurfacingProvider.js` notes this in a comment). A proper renderer-side path (a Tauri command, or the MCP server) would make a good follow-up and I am happy to help. If you would rather fix this a different way (make `graphIndex.js` itself browser-safe, or stop the renderer importing it directly), point me at the preferred shape and I will redo it.

**Related issue(s):**

Closes #535

## 🧪 Testing

**How was this tested?**
- [x] Manual testing performed

**Test scenarios covered:**

- `npm run build` on `ubuntu-latest` x86_64 and on a native riscv64 board, both complete.
- Minimal CI job (`npm install` + `npm run build`) on `ubuntu-latest`, green: https://github.com/gounthar/lokus/actions/runs/28603195900 . I kept that workflow out of this PR; glad to add a client-build check to CI if you want one.
- `npm ci` currently fails on `main` for an unrelated lockfile mismatch (`package-lock.json` out of sync with `package.json`), so I used `npm install`. Filed as part of #535; can send a lockfile refresh separately.

## 📋 Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

**For bug fixes:**
- [x] I have verified the fix works in different scenarios
- [x] I have considered edge cases

I did not add a unit test, this is a bundling/config fix; a CI client-build check would be the natural regression guard and I am glad to add one if you want it here.

## 🔄 Breaking Changes

None on the Node/MCP side. In the renderer, graph-backed related-notes return empty (they were non-functional there already).
